### PR TITLE
fix: write Claude activity summary to GITHUB_STEP_SUMMARY

### DIFF
--- a/.github/actions/run-skill/action.yml
+++ b/.github/actions/run-skill/action.yml
@@ -78,5 +78,5 @@ runs:
           Read and follow the skill defined in `Token-Effort/plugins/token-effort/skills/${{ inputs.skill_name }}/SKILL.md`.
           ${{ inputs.prompt }}
 
-          Upon completion, log a summary of your activity using `echo "::notice::[Claude] {Activity summary}"`
+          Upon completion, write a brief markdown summary of your activity to the GitHub Actions step summary using: SUMMARY_FILE=$(printenv GITHUB_STEP_SUMMARY) && echo "**[Claude]** {Activity summary}" >> "$SUMMARY_FILE"
         claude_args: ${{ steps.build_args.outputs.value }}


### PR DESCRIPTION
## Summary

- Replaces the broken `::notice::` workflow command with a write to `$GITHUB_STEP_SUMMARY`
- Uses `printenv GITHUB_STEP_SUMMARY` to safely read the env var inside Claude's sandboxed `Bash` tool
- No new inputs, steps, or structural changes — all existing callers work unchanged

## Test Plan

- [x] Trigger the `Triage GitHub Issues` workflow
- [x] Wait for completion, open the Actions run
- [x] Verify a `**[Claude]** ...` line appears in the "Summary" tab

Closes #35