### PR TITLE
fix: guard release workflow against re-releasing existing versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,13 @@ jobs:
           token: ${{ steps.release-manager-token.outputs.token }}
           fetch-depth: 1
 
+      - name: 🔍 Check tag does not exist
+        run: |
+          if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
+            echo "Tag v$VERSION already exists. Aborting."
+            exit 1
+          fi
+
       - name: 📝 Patch plugin.json version
         run: |
           jq --arg version "$VERSION" '.version = $version' \
@@ -52,15 +59,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add plugins/token-effort/.claude-plugin/plugin.json
-          git commit -m "chore: release v$VERSION"
+          git diff --cached --quiet || git commit -m "chore: release v$VERSION"
           git push origin HEAD
-
-      - name: 🔍 Check tag does not exist
-        run: |
-          if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
-            echo "Tag v$VERSION already exists. Aborting."
-            exit 1
-          fi
 
       - name: 🏷️ Create git tag
         run: |


### PR DESCRIPTION
## Summary

- Moves the \"Check tag does not exist\" step to immediately after checkout, before any write operations, so the workflow aborts cleanly when re-releasing an already-tagged version
- Makes the \"Commit and push version bump\" step idempotent via \`git diff --cached --quiet || git commit …\` so retry scenarios (version bumped but tag not yet created) no longer fail on a clean working tree

## Test Plan

- [ ] Trigger the release workflow with an already-released version (e.g. \`0.1.0\`) — expect \"Check tag does not exist\" to abort with \`Tag v0.1.0 already exists. Aborting.\` before any commit or push occurs
- [ ] Trigger with a new valid version — expect the full workflow to complete: patch → commit → tag → release
- [ ] Simulate retry: manually set \`plugin.json\` to the target version and push, trigger the workflow with that version and no corresponding tag — expect the commit step to skip gracefully and the workflow to proceed to tag and release

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)