### PR TITLE
fix: adopt post-hoc extraction strategy for brainstorming-gh-issue spec (#42)

### DIFF
--- a/plugins/token-effort/skills/brainstorming-gh-issue/SKILL.md
+++ b/plugins/token-effort/skills/brainstorming-gh-issue/SKILL.md
@@ -106,17 +106,27 @@ If re-entry mode and a prior spec was found, append:
 Inject this block into the conversation, then invoke `superpowers:brainstorming` with the following instructions:
 
 - Treat the issue content above as the user's starting brief. Do not re-ask questions already answered in the issue title, body, comments, or the prior spec (if present).
-- **Do NOT write or commit a spec file to disk.** The brainstorming skill's "Write design doc" step must be skipped entirely. After the user approves the design, hold the approved content in context — this skill resumes in Phase 4 to post it to GitHub.
+- Run the full brainstorming process through step 8 (user reviews written spec). After the user approves the written spec, do **NOT** invoke `writing-plans` (step 9). Proceed to Phase 4 of this skill instead.
 
 Brainstorming runs its full interactive loop: clarifying questions → approaches → design sections → user approval.
 
-After the user approves the design, proceed to Phase 4.
+After the user approves the written spec, proceed to Phase 4.
 
 ### Phase 4 — Post spec and apply label
 
+#### Pre-step — Locate and read the spec file
+
+Brainstorming will have written the spec to `docs/superpowers/specs/`. Find the most recently created file:
+
+```bash
+ls -t docs/superpowers/specs/*.md | head -1
+```
+
+Read the file content. Use this content as the spec body in step 4a. Do **not** reconstruct the spec from memory.
+
 #### Step 4a — Post spec as a GitHub comment
 
-Take the approved design content and post it to the issue as a comment using this exact format:
+Take the spec file content and post it to the issue as a comment using this exact format:
 
 ```
 <!-- brainstorming-gh-issue:spec -->
@@ -156,6 +166,15 @@ gh label create "pending-review" --color "#FEF2C0" --description "Spec posted, a
 gh issue edit <N> --add-label "pending-review"
 ```
 
+#### Step 4d — Clean up the local spec file
+
+Delete the spec file brainstorming wrote and commit the deletion:
+
+```bash
+git rm <spec-file-path>
+git commit -m "chore: remove brainstorming spec (posted to issue #<N>)"
+```
+
 After Phase 4 completes, report:
 
 > "Done. Spec posted to issue #<N> and labelled `pending-review`."
@@ -163,13 +182,16 @@ After Phase 4 completes, report:
 ## Common Mistakes
 
 - **Using MCP tools for issue operations** — all issue interactions must use `gh` CLI commands. Never call any `mcp__plugin_github_github__*` tool, even if it is available.
-- **Writing the spec file to disk** — the brainstorming skill's file-write and commit steps must be skipped. The spec goes to GitHub as a comment, not to `docs/superpowers/specs/`. Do not run `git add` or `git commit` at any point.
+- **Invoking `writing-plans` after the user approves the spec** — the Phase 3 handoff instructs brainstorming to stop after step 8. Do not invoke `writing-plans` (step 9); proceed to Phase 4 instead.
+- **Not reading the spec file before posting** — always locate and read the file brainstorming committed with `ls -t docs/superpowers/specs/*.md | head -1`. Do not reconstruct the spec content from memory.
+- **Forgetting to clean up the local spec file** — after posting to GitHub, run `git rm <spec-file-path>` and commit the deletion. The spec file must not remain on disk.
 - **Posting the spec before the user approves it** — Phase 4 must not run until the user has explicitly approved the design within the brainstorming session. Do not call `gh issue comment` or `gh issue edit` during Phase 3.
 - **Forgetting the HTML comment marker** — the spec comment must begin with `<!-- brainstorming-gh-issue:spec -->` on its own line so future re-entry runs can locate it reliably.
 - **Creating `pending-review` without checking first** — always run `gh label list` before `gh label create` to avoid an error if the label already exists.
 - **Re-asking questions answered in the issue** — the issue title, body, and comments are the starting brief. Instruct brainstorming not to repeat questions already answered there.
 - **Using shell expansion syntax** — never use `${VARIABLE}`, `${VARIABLE:-}`, or any `${...}` form. Claude Code's sandbox blocks these. Use `printenv VARIABLE` to read environment variables.
 - **Asking the user to choose when no choice is needed** — branch name auto-detection always uses the first integer. Only ask the user to choose when multiple numbers were explicitly provided as arguments.
+- **Making unexpected git commits** — `brainstorming-gh-issue` itself must never run `git add` or `git commit` directly. The only expected commits are: brainstorming's natural spec commit (from the brainstorming skill) and Phase 4's cleanup commit (`git rm <spec-file>`). Do not commit anything else.
 
 ## Eval
 
@@ -182,11 +204,13 @@ After Phase 4 completes, report:
 - [ ] Identified the presence of `pending-review` label and searched comments for `<!-- brainstorming-gh-issue:spec -->`
 - [ ] In re-entry mode with spec found: loaded both issue context and prior spec into Phase 3
 - [ ] In re-entry mode with no spec found: noted the absence and proceeded as a fresh brainstorm without erroring
-- [ ] The Phase 3 handoff explicitly instructed brainstorming to skip writing/committing the spec file
+- [ ] The Phase 3 handoff instructed brainstorming to stop after step 8 and not invoke `writing-plans`
 - [ ] The Phase 3 handoff instructed brainstorming not to re-ask questions answered in the issue or prior spec
 - [ ] `superpowers:brainstorming` was invoked (not re-implemented inline)
 - [ ] `gh issue comment` was NOT called until after the user approved the design
 - [ ] `gh issue edit --add-label pending-review` was NOT called until after user approval
+- [ ] Phase 4 located the spec file with `ls -t docs/superpowers/specs/*.md | head -1`
+- [ ] Phase 4 read the spec file content before constructing the GitHub comment
 - [ ] The spec comment body starts with `<!-- brainstorming-gh-issue:spec -->`
 - [ ] The spec comment contains the heading `## 🤖🧠 Design Spec`
 - [ ] The spec comment footer contains "Mistakes do happen"
@@ -194,7 +218,6 @@ After Phase 4 completes, report:
 - [ ] `gh label list` was called before attempting to create or apply `pending-review`
 - [ ] `gh label create "pending-review"` was called only when the label was absent from `gh label list` output
 - [ ] `gh issue edit <N> --add-label "pending-review"` was called after the spec comment was posted
-- [ ] No file was written to `docs/superpowers/specs/` or any other path on disk
-- [ ] No `git add` or `git commit` was run
+- [ ] Phase 4 ran `git rm <spec-file>` and committed the deletion after posting to GitHub
 - [ ] No `mcp__` tool was called at any point
 - [ ] A completion message was shown after Phase 4, referencing the issue number

--- a/training/skills/brainstorming-gh-issue/common-mistakes-section-present.md
+++ b/training/skills/brainstorming-gh-issue/common-mistakes-section-present.md
@@ -5,12 +5,12 @@ The `brainstorming-gh-issue` SKILL.md is read by an engineer preparing to implem
 ## Expected Behaviour
 
 - The skill file includes a "Common Mistakes" section that explicitly lists the anti-patterns most likely to cause failures.
-- At minimum, the section covers: using MCP tools, writing the spec file to disk, posting the spec before user approval, forgetting the HTML comment marker, creating a label without checking first, and using shell expansion syntax.
+- At minimum, the section covers: using MCP tools, invoking `writing-plans` after the user approves the spec, posting the spec before user approval, forgetting the HTML comment marker, and creating a label without checking first.
 
 ## Pass Criteria
 
 - [ ] A "Common Mistakes" section exists in the SKILL.md.
 - [ ] The section lists at least 5 distinct anti-patterns.
 - [ ] The anti-pattern of using MCP tools is explicitly called out.
-- [ ] The anti-pattern of writing the spec file to disk is explicitly called out.
+- [ ] The anti-pattern of invoking `writing-plans` instead of proceeding to Phase 4 is explicitly called out.
 - [ ] The anti-pattern of posting the spec before user approval is explicitly called out.

--- a/training/skills/brainstorming-gh-issue/eval-checklist-present.md
+++ b/training/skills/brainstorming-gh-issue/eval-checklist-present.md
@@ -5,14 +5,14 @@ The `brainstorming-gh-issue` SKILL.md is reviewed for its Eval section, which is
 ## Expected Behaviour
 
 - The SKILL.md contains an "Eval" section with a checklist of binary pass/fail criteria.
-- The criteria cover all major behaviours: issue resolution, re-entry detection, brainstorming handoff overrides, spec comment format, label management, and negative behaviours (no MCP, no file writes, no premature posting).
+- The criteria cover all major behaviours: issue resolution, re-entry detection, brainstorming handoff instructions, spec comment format, label management, Phase 4 file handling, and negative behaviours (no MCP, no premature posting).
 
 ## Pass Criteria
 
 - [ ] An "Eval" section exists in the SKILL.md with at least 8 checkbox criteria.
 - [ ] At least one criterion covers issue resolution from args or branch.
 - [ ] At least one criterion covers re-entry detection via the spec comment marker.
-- [ ] At least one criterion covers the instruction to skip the spec file write.
+- [ ] At least one criterion covers the Phase 3 handoff instruction to stop after step 8 and not invoke `writing-plans`.
 - [ ] At least one criterion covers the spec comment format (marker, heading, footer).
 - [ ] At least one criterion covers `pending-review` label management.
-- [ ] At least one negative criterion (e.g. "no MCP tool was called" or "no file was written to disk").
+- [ ] At least one negative criterion (e.g. "no MCP tool was called" or "Phase 4 ran `git rm`").

--- a/training/skills/brainstorming-gh-issue/no-file-write-to-disk.md
+++ b/training/skills/brainstorming-gh-issue/no-file-write-to-disk.md
@@ -1,16 +1,20 @@
 ## Scenario
 
-The user runs `/brainstorming-gh-issue 28`. Brainstorming runs and the user approves a design. The `superpowers:brainstorming` skill would normally write the spec to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit it.
+The user runs `/brainstorming-gh-issue 28`. Brainstorming runs its full process through step 8, writes the spec to `docs/superpowers/specs/2026-04-07-my-feature-design.md`, and commits it. The user approves the written spec.
 
 ## Expected Behaviour
 
-- The skill explicitly instructs `superpowers:brainstorming` to skip the file write and git commit steps.
-- No spec file is created anywhere on disk.
-- The approved design content is held in context and posted to GitHub instead.
+- The Phase 3 handoff instructs brainstorming to stop after step 8 and not invoke `writing-plans` (step 9).
+- Phase 4 locates the spec file brainstorming committed using `ls -t docs/superpowers/specs/*.md | head -1`.
+- Phase 4 reads the spec file content before constructing the GitHub comment.
+- Phase 4 posts the spec file content to GitHub as a comment.
+- Phase 4 deletes the local spec file with `git rm` and commits the deletion.
 
 ## Pass Criteria
 
-- [ ] The handoff instructions to `superpowers:brainstorming` explicitly state that writing/committing the spec file must be skipped.
-- [ ] No file is written to `docs/superpowers/specs/` or any other path.
-- [ ] No `git add` or `git commit` is run for the spec content.
-- [ ] The spec content is posted to GitHub as a comment in Phase 4.
+- [ ] The Phase 3 handoff instructs brainstorming not to invoke `writing-plans` after step 8.
+- [ ] Phase 4 runs `ls -t docs/superpowers/specs/*.md | head -1` to locate the spec file.
+- [ ] Phase 4 reads the spec file before posting — content comes from the file, not reconstructed from memory.
+- [ ] `gh issue comment` is called with the spec file's content.
+- [ ] `git rm` is run on the spec file after posting to GitHub.
+- [ ] A commit is made removing the spec file, with a message referencing the issue number.

--- a/training/skills/brainstorming-gh-issue/no-git-commit.md
+++ b/training/skills/brainstorming-gh-issue/no-git-commit.md
@@ -1,15 +1,18 @@
 ## Scenario
 
-The user runs `/brainstorming-gh-issue 28`. Brainstorming completes, the spec is posted to GitHub, and the label is applied. The session ends.
+The user runs `/brainstorming-gh-issue 28`. Brainstorming completes and writes a spec file to `docs/superpowers/specs/`. The user approves the spec. Phase 4 posts it to GitHub and applies the label.
 
 ## Expected Behaviour
 
-- At no point during the skill's execution is `git add`, `git commit`, or any other git write command run.
-- All output goes to GitHub via `gh` CLI, not to the local git repository.
+- Brainstorming's natural commit of the spec file is expected and allowed.
+- Phase 4 runs `git rm <spec-file>` after posting to GitHub and commits the deletion.
+- The cleanup commit message references the issue number.
+- No other git commits are made by `brainstorming-gh-issue` directly.
 
 ## Pass Criteria
 
-- [ ] `git add` is never called.
-- [ ] `git commit` is never called.
-- [ ] The skill does not instruct the engineer to commit any files.
-- [ ] The skill's Common Mistakes or instructions explicitly note that no files should be committed.
+- [ ] Brainstorming's commit of the spec file is treated as expected behaviour (not flagged as an error).
+- [ ] Phase 4 runs `git rm <spec-file-path>` after posting the spec to GitHub.
+- [ ] A commit is made removing the spec file.
+- [ ] The cleanup commit message references the issue number (e.g. `chore: remove brainstorming spec (posted to issue #28)`).
+- [ ] No other `git add` or `git commit` commands are run by the skill itself.


### PR DESCRIPTION
## Summary

- Phase 3 now instructs `superpowers:brainstorming` to run through step 8 (written spec) but stop before invoking `writing-plans` (step 9)
- Phase 4 gains a pre-step to locate the committed spec file (`ls -t docs/superpowers/specs/*.md | head -1`), read it, and post its content to GitHub; then a new step 4d to clean up via `git rm` + commit
- Common Mistakes updated: removed "writing spec file to disk" (now expected), added "invoking `writing-plans`", "not reading spec file before posting", "forgetting cleanup", and updated the git commit guidance
- Eval checklist updated to match; four training evals repurposed/updated to reflect the new behaviour

Closes #42

## Test Plan

- [ ] Training baseline passes 135/135 criteria across 35 evals

🤖 Generated with [Claude Code](https://claude.com/claude-code)