### PR TITLE
feat: add /propose-feature skill

### DIFF
--- a/plugins/token-effort/skills/propose-feature/SKILL.md
+++ b/plugins/token-effort/skills/propose-feature/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: propose-feature
+description: Use when the user wants to file a new GitHub feature request through a guided interview.
+user-invocable: true
+---
+
+# 📝 Propose a Feature
+
+## Overview
+
+Guides the user through filing a well-structured GitHub feature request. Discovers any existing issue templates for the current repo, conducts a conversational interview to gather problem motivation, use cases, and proposed solution, shows a formatted draft for review, and files the issue via `gh issue create`.
+
+**Usage:** `/propose-feature`
+
+## When to Use
+
+**Use when:**
+- The user wants to file a new feature request and wants to ensure they capture the right context
+- The user has a rough idea and wants help shaping it into a clear GitHub issue
+
+**Do not use when:**
+- The issue already exists on GitHub — use `/brainstorming-gh-issue` to turn it into a design spec instead
+- The user wants to file a bug report — this skill is for feature/enhancement requests only
+
+## Prerequisites
+
+The `gh` CLI must be authenticated and available in the session. All GitHub operations use `gh` commands via Bash. No MCP tools are used or required.
+
+> **Important:** Do **not** use MCP tools (`mcp__plugin_github_github__*`) for any issue operation.
+
+> **Shell expansion:** Never use `${VARIABLE}` or `${...}` form in bash commands. Claude Code's sandbox blocks these.
+
+## Process
+
+### Phase 1 — Template Discovery
+
+Check for GitHub issue templates in the current repo:
+
+```bash
+ls .github/ISSUE_TEMPLATE/ 2>/dev/null
+```
+
+For each file returned (`.md` or `.yml` extensions), read its content. Identify any template whose **filename** contains "feature" or "enhancement", or whose **frontmatter `labels` field** contains "feature" or "enhancement".
+
+- **Template found:** Extract the template body/sections. Use these sections to structure the interview in Phase 2 (e.g., if the template has a "Is your feature request related to a problem?" section, use that as the opening prompt).
+- **No matching template found** (directory missing, empty, or no feature/enhancement template): Fall back to the built-in interview questions below. Do not warn the user — proceed silently.
+
+### Phase 2 — Interview
+
+Conduct a **conversational** interview. Do not dump all questions at once. Let each answer inform what to ask next.
+
+**Built-in question set** (used when no template found, or as a baseline when a template is found):
+
+1. **Opening (always first):** "What problem are you trying to solve?" — Understand the motivation before the solution.
+2. **Use cases:** Who experiences this problem? In what scenarios? (Ask only if not clear from the opening answer.)
+3. **Proposed solution:** What solution are you proposing? (Ask only after understanding the problem.)
+4. **Alternatives:** Have you considered any alternatives? (Skip if the user already addressed this.)
+5. **Constraints:** Any scope limits, constraints, or out-of-scope items worth noting? (Ask if the feature seems broad.)
+6. **Title:** Ask the user for a concise issue title (5–10 words) before moving to Phase 3. If a clear title emerged naturally from the interview, propose it and ask the user to confirm or adjust.
+
+Keep the interview brief — stop asking when you have enough for a complete, actionable issue. Three to five substantive exchanges is usually sufficient.
+
+### Phase 3 — Draft and Review
+
+Format the collected answers into an issue body. Structure depends on whether a template was used:
+
+- **If template matched:** Fill in the template's sections with the user's answers. Preserve the template's section headings.
+- **If fallback:** Use this standard structure:
+
+```
+**Problem**
+<what problem this solves>
+
+**Proposed Solution**
+<what the user wants to build or change>
+
+**Use Cases**
+<who benefits and in what scenarios>
+
+**Alternatives Considered**
+<other approaches and why they were ruled out>
+```
+
+Omit any section for which no information was collected.
+
+Show the user the full draft:
+
+```
+**Title:** <title>
+
+---
+<formatted body>
+```
+
+Ask: "Does this look right? Any changes before I file it?"
+
+Allow the user to request edits. After each round of edits, re-display the **full updated draft** (title + body) and ask for approval again. Repeat until the user gives explicit approval (e.g., "looks good", "file it", "yes").
+
+### Phase 4 — File the Issue
+
+Once the user approves, run:
+
+```bash
+gh issue create --title "<title>" --body "<body>"
+```
+
+Use no additional flags — no `--label`, `--assignee`, or `--milestone`.
+
+`gh issue create` prints the URL of the new issue. Report it to the user:
+
+> "Done. Issue filed: \<url\>"
+
+## Common Mistakes
+
+- **Using MCP tools** — all issue interactions must use `gh` CLI commands only.
+- **Filing before user approval** — `gh issue create` must NOT be called until the user explicitly approves the draft in Phase 3.
+- **Dumping all interview questions at once** — the interview must be conversational; let answers drive follow-up questions.
+- **Forgetting to ask for a title** — always confirm a concise title before Phase 3.
+- **Using `${VARIABLE}` shell expansion** — not supported in Claude Code's sandbox; avoid.
+- **Applying labels, assignees, or milestones** — file with no extra metadata per skill design.
+- **Silently failing template discovery** — if `.github/ISSUE_TEMPLATE/` doesn't exist, fall back to built-in questions without warning.
+- **Asking about feature vs. bug** — this skill is feature/enhancement only; do not prompt the user to choose a type.
+
+## Eval
+
+- [ ] Ran `ls .github/ISSUE_TEMPLATE/ 2>/dev/null` to check for templates
+- [ ] Read and checked template filenames/frontmatter for "feature" or "enhancement"
+- [ ] When a matching template was found: used its sections to frame the interview
+- [ ] When no matching template: fell back to built-in questions silently (no warning to user)
+- [ ] Interview opened with a problem-focused question, not a solution question
+- [ ] Follow-up questions were conversational, not asked all at once
+- [ ] Asked the user to confirm or provide a concise title before drafting
+- [ ] Showed a formatted draft preview (title + body) before filing
+- [ ] Allowed the user to request edits and iterated until explicit approval
+- [ ] Did NOT call `gh issue create` until user explicitly approved
+- [ ] Called `gh issue create --title "..." --body "..."` with no extra flags
+- [ ] Reported the filed issue URL to the user
+- [ ] No `mcp__` tool was called at any point

--- a/training/skills/propose-feature/draft-shown-before-filing.md
+++ b/training/skills/propose-feature/draft-shown-before-filing.md
@@ -1,0 +1,10 @@
+## Scenario
+The interview is complete and a title is confirmed. Claude is ready to file.
+
+## Expected Behavior
+Claude formats the draft as `**Title:** <title>\n---\n<body>` and shows it to the user, asking if it looks right before filing.
+
+## Pass Criteria
+- [ ] Showed the formatted draft to the user including the title
+- [ ] Asked for explicit approval before calling `gh issue create`
+- [ ] Offered the user a chance to request edits

--- a/training/skills/propose-feature/edit-iteration.md
+++ b/training/skills/propose-feature/edit-iteration.md
@@ -1,0 +1,11 @@
+## Scenario
+The draft is shown. The user says "change the title to X" and "add a note about Y in the proposed solution". Claude updates the draft and shows it again.
+
+## Expected Behavior
+Claude incorporates the requested changes, re-renders the draft, and asks again for approval before filing.
+
+## Pass Criteria
+- [ ] Applied all requested edits to the draft
+- [ ] Re-displayed the full updated draft after edits
+- [ ] Asked for approval again after showing the revised draft
+- [ ] Did not call `gh issue create` until the revised draft was explicitly approved

--- a/training/skills/propose-feature/gh-issue-create-no-extra-flags.md
+++ b/training/skills/propose-feature/gh-issue-create-no-extra-flags.md
@@ -1,0 +1,10 @@
+## Scenario
+The user approves the draft. Claude files the issue.
+
+## Expected Behavior
+Claude calls `gh issue create --title "<title>" --body "<body>"` with no additional flags — no `--label`, `--assignee`, or `--milestone`.
+
+## Pass Criteria
+- [ ] Called `gh issue create` with `--title` and `--body` only
+- [ ] Did not pass `--label`, `--assignee`, `--milestone`, or any other flag
+- [ ] Reported the issue URL returned by `gh issue create` to the user

--- a/training/skills/propose-feature/interview-conversational-not-bulk.md
+++ b/training/skills/propose-feature/interview-conversational-not-bulk.md
@@ -1,0 +1,10 @@
+## Scenario
+The user invokes `/propose-feature`. The skill starts the interview.
+
+## Expected Behavior
+Claude asks one question, waits for the answer, then decides what to ask next based on that answer. It does not dump all 5-6 questions in a single message.
+
+## Pass Criteria
+- [ ] Each message contains at most one interview question
+- [ ] Follow-up questions are informed by prior answers (e.g., skips "alternatives" if user already mentioned them)
+- [ ] Interview ends when enough information is collected (not necessarily after all 6 questions)

--- a/training/skills/propose-feature/interview-opens-with-problem.md
+++ b/training/skills/propose-feature/interview-opens-with-problem.md
@@ -1,0 +1,10 @@
+## Scenario
+No template is found. The user invokes `/propose-feature` and waits for the first question.
+
+## Expected Behavior
+Claude's very first question focuses on the problem/motivation, not the solution.
+
+## Pass Criteria
+- [ ] First question asked is about the problem or motivation (e.g., "What problem are you trying to solve?")
+- [ ] First question is NOT about the proposed solution, use cases, or title
+- [ ] Only one question is asked at a time (not all questions at once)

--- a/training/skills/propose-feature/no-filing-before-approval.md
+++ b/training/skills/propose-feature/no-filing-before-approval.md
@@ -1,0 +1,10 @@
+## Scenario
+The draft has been shown. The user says "hmm, let me think" without giving approval. Claude waits.
+
+## Expected Behavior
+Claude does NOT call `gh issue create` until the user gives explicit approval (e.g., "looks good", "file it", "yes").
+
+## Pass Criteria
+- [ ] Did not call `gh issue create` when user response was ambiguous or non-approving
+- [ ] Continued waiting for explicit user approval
+- [ ] Allowed the user to request additional edits to the draft

--- a/training/skills/propose-feature/no-mcp-tools.md
+++ b/training/skills/propose-feature/no-mcp-tools.md
@@ -1,0 +1,10 @@
+## Scenario
+The user invokes `/propose-feature` in a session where MCP GitHub tools are available.
+
+## Expected Behavior
+Claude uses only `gh` CLI commands via Bash for all GitHub operations. No `mcp__` tool calls are made at any point.
+
+## Pass Criteria
+- [ ] No `mcp__` tool was invoked during the entire skill execution
+- [ ] Template discovery used `ls .github/ISSUE_TEMPLATE/` via Bash
+- [ ] Issue creation used `gh issue create` via Bash

--- a/training/skills/propose-feature/no-shell-expansion.md
+++ b/training/skills/propose-feature/no-shell-expansion.md
@@ -1,0 +1,9 @@
+## Scenario
+Claude constructs a bash command that could use shell variable expansion (e.g., to pass title or body).
+
+## Expected Behavior
+Claude does not use `${VARIABLE}` or `${...}` syntax in any Bash command. It uses literal values or alternative forms.
+
+## Pass Criteria
+- [ ] No `${...}` variable expansion syntax appears in any Bash command issued
+- [ ] `gh issue create` call uses literal title/body strings, not shell variables

--- a/training/skills/propose-feature/reports-issue-url.md
+++ b/training/skills/propose-feature/reports-issue-url.md
@@ -1,0 +1,10 @@
+## Scenario
+`gh issue create` succeeds and prints a URL. Claude reports it to the user.
+
+## Expected Behavior
+Claude reports the URL of the newly created issue, e.g. "Done. Issue filed: <url>".
+
+## Pass Criteria
+- [ ] Reported the issue URL to the user after successful creation
+- [ ] Message indicated the issue was successfully filed
+- [ ] Did not silently discard the URL output from `gh issue create`

--- a/training/skills/propose-feature/template-discovery-feature-found.md
+++ b/training/skills/propose-feature/template-discovery-feature-found.md
@@ -1,0 +1,11 @@
+## Scenario
+The repo has `.github/ISSUE_TEMPLATE/feature_request.md` in its templates directory. The user invokes `/propose-feature`.
+
+## Expected Behavior
+Claude reads the template, identifies it as a feature/enhancement template (filename contains "feature"), and uses its sections to frame the interview questions.
+
+## Pass Criteria
+- [ ] Ran `ls .github/ISSUE_TEMPLATE/ 2>/dev/null` to discover templates
+- [ ] Read the feature template file content
+- [ ] Used the template's section headings to structure the interview
+- [ ] Did not fall back to built-in question set

--- a/training/skills/propose-feature/template-discovery-missing-directory.md
+++ b/training/skills/propose-feature/template-discovery-missing-directory.md
@@ -1,0 +1,10 @@
+## Scenario
+The repo has no `.github/ISSUE_TEMPLATE/` directory at all. The user invokes `/propose-feature`.
+
+## Expected Behavior
+Claude silently falls back to built-in questions. No error or warning is shown to the user.
+
+## Pass Criteria
+- [ ] Ran `ls .github/ISSUE_TEMPLATE/ 2>/dev/null` (with stderr suppressed)
+- [ ] Did not warn the user that no template directory was found
+- [ ] Proceeded with built-in interview questions immediately

--- a/training/skills/propose-feature/template-discovery-no-match.md
+++ b/training/skills/propose-feature/template-discovery-no-match.md
@@ -1,0 +1,11 @@
+## Scenario
+The repo has `.github/ISSUE_TEMPLATE/bug_report.md` only. No feature or enhancement template exists. The user invokes `/propose-feature`.
+
+## Expected Behavior
+Claude falls back to built-in interview questions silently, without informing the user that no template was found.
+
+## Pass Criteria
+- [ ] Ran `ls .github/ISSUE_TEMPLATE/ 2>/dev/null`
+- [ ] Read the bug report template, determined it was not a feature/enhancement template
+- [ ] Fell back to built-in questions without warning the user
+- [ ] Interview opened with "What problem are you trying to solve?" or equivalent

--- a/training/skills/propose-feature/title-confirmed-before-draft.md
+++ b/training/skills/propose-feature/title-confirmed-before-draft.md
@@ -1,0 +1,10 @@
+## Scenario
+The interview has gathered problem, use cases, and proposed solution. The user has not yet mentioned a title. Claude is about to move to Phase 3.
+
+## Expected Behavior
+Claude asks the user to provide or confirm a concise issue title (5–10 words) before presenting the draft.
+
+## Pass Criteria
+- [ ] Asked the user to provide or confirm a title before showing the draft
+- [ ] If a natural title emerged from the interview, proposed it and asked the user to confirm or adjust
+- [ ] Did not proceed to Phase 3 without a confirmed title


### PR DESCRIPTION
## Summary

- Implements the `/propose-feature` skill from the design spec in issue #40
- Guides users through a conversational interview to capture problem, use cases, proposed solution, and title before filing a GitHub feature request via `gh issue create`
- Includes 13 eval cases covering template discovery, interview flow, draft review/iteration, and filing guard-rails

Closes #40

## Test Plan

- [x] Invoke `/propose-feature` in a repo with a feature issue template — verify template sections are used to frame the interview
- [ ] Invoke `/propose-feature` in a repo with no matching template — verify fallback to built-in questions with no warning
- [x] Verify interview is conversational (one question at a time, not a bulk dump)
- [x] Verify `gh issue create` is not called until explicit user approval
- [ ] Verify filed issue URL is reported to the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)