### PR TITLE
feat: add /build skill and move-issue-status helper

### DIFF
--- a/plugins/token-effort/skills/build/SKILL.md
+++ b/plugins/token-effort/skills/build/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: build
+description: Use when implementing a GitHub issue end-to-end — from design spec to merged PR.
+user-invocable: true
+---
+
+# Build
+
+## Overview
+
+Implements a GitHub issue end-to-end: fetches the issue and its approved design spec, moves the issue to "Building" status, writes and approves an implementation plan, executes the plan, verifies and reviews the result, and opens a pull request. The process is gated at the planning stage — execution does not begin until a plan has been approved. The pull request is created exactly once, at the final phase.
+
+**Usage:** `/token-effort:build <issue-number>`
+
+Strip any leading `#` from the issue number before use (e.g. `#42` → `42`).
+
+## When to Use
+
+**Use when:**
+- A GitHub issue has an approved design spec comment (produced by `token-effort:brainstorming-gh-issue`) and is ready to be implemented
+- You want a structured, end-to-end build workflow from spec to merged PR
+
+**Do not use when:**
+- The issue does not yet have a design spec comment — run `/token-effort:brainstorming-gh-issue <N>` first and get the spec approved
+- Implementation is already underway on a branch — join that branch directly instead
+
+## Prerequisites
+
+- `gh` CLI must be authenticated and available in the session. All GitHub operations use `gh` commands via `Bash`. No MCP tools are used or required.
+- The issue must have a design spec comment whose body begins with `<!-- brainstorming-gh-issue:spec -->`, produced by `token-effort:brainstorming-gh-issue`.
+- The following `superpowers` skills must be installed:
+  - `superpowers:writing-plans`
+  - `superpowers:executing-plans`
+  - `superpowers:subagent-driven-development`
+  - `superpowers:finishing-a-development-branch`
+
+> **Important:** Do **not** use MCP tools (`mcp__plugin_github_github__*`) for any issue or GitHub operation.
+
+## Process
+
+### Phase 1 — Fetch issue and extract spec
+
+Run:
+
+```bash
+gh issue view <N> --json number,title,body,comments,labels
+```
+
+Search the `comments` array for a comment whose body starts with `<!-- brainstorming-gh-issue:spec -->`.
+
+**If no such comment is found:** Stop immediately with the error:
+
+> "Issue #N does not have a design spec comment. Run `/token-effort:brainstorming-gh-issue <N>` to generate one, then get it approved before building."
+
+**If found:** Extract the spec body — the full comment content **after** stripping the `<!-- brainstorming-gh-issue:spec -->` marker line. This stripped body is the spec context used in Phase 3.
+
+### Phase 2 — Move issue to Building status
+
+Invoke: `token-effort:move-issue-status <N> "Building"`
+
+If this fails for any reason (e.g. the issue is not on a project board, or the skill is unavailable), **log a warning and continue**. This phase is non-fatal — do not block the build on a status update failure.
+
+### Phase 3 — Write implementation plan
+
+Invoke: `superpowers:writing-plans`
+
+Pass the spec body extracted in Phase 1 as the context. `writing-plans` runs its own user-approval loop — wait for it to complete and for a plan to be approved before proceeding to Phase 4.
+
+### Phase 4 — Execute plan
+
+Assess the plan produced by Phase 3. Choose the execution skill:
+
+| Skill | When to use |
+|-------|-------------|
+| `superpowers:executing-plans` | **Default.** Use for most plans. |
+| `superpowers:subagent-driven-development` | Use **only** when ALL THREE of the following apply: (1) the plan has many independent tasks with no sequential dependencies between them, (2) changes span 5 or more separate subsystems/modules, and (3) the plan is explicitly scoped as large or complex. |
+
+Invoke the chosen skill with the following **mandatory suppression instruction** included verbatim in the prompt:
+
+> "Do not invoke `finishing-a-development-branch` — this will be handled by the calling skill after all review steps complete."
+
+This instruction is required regardless of which execution skill is chosen. Do not paraphrase or omit it.
+
+### Phase 5 — Verify (optional)
+
+Attempt to invoke the project-local `/verify` skill.
+
+If `/verify` is not available or not found, log the following named warning and continue:
+
+> "⚠️ Phase 5 skipped: `/verify` skill not available in this project"
+
+Do not block on this phase.
+
+### Phase 6 — Inline simplify pass
+
+Review all changed code directly using Claude's built-in reasoning. No separate skill invocation is needed.
+
+Check for:
+- Unnecessary duplication
+- Opportunities to reuse existing utilities
+- Over-engineering
+- Efficiency issues
+
+Fix any issues found directly. Report a brief summary of changes made, or "No changes needed" if nothing required fixing.
+
+### Phase 7 — Code review
+
+Invoke: `token-effort:reviewing-code-systematically`
+
+Address any `BLOCK` or `NEEDS_CHANGES` findings before continuing to Phase 8.
+
+### Phase 8 — Inline security review
+
+Review all changed code directly using Claude's built-in reasoning. No separate skill invocation is needed.
+
+Check for:
+- Injection vulnerabilities
+- Insecure credential handling
+- Exposed secrets
+- Unsafe shell expansion
+- OWASP Top 10 concerns relevant to the changes
+
+Fix any issues found directly. Report a brief summary of findings, or "No security issues found" if the review was clean.
+
+### Phase 9 — Record decisions (optional)
+
+Attempt to invoke: `token-effort:recording-decisions`
+
+If the skill is not available, log the following named warning and continue:
+
+> "⚠️ Phase 9 skipped: `token-effort:recording-decisions` skill not available (planned; see issue #49)"
+
+Do not block on this phase.
+
+### Phase 10 — Finish development branch
+
+Invoke: `superpowers:finishing-a-development-branch`
+
+This step creates the pull request. It runs exactly once, here, at the end of the build process. The execution skills in Phase 4 must not call it — that is what the suppression instruction in Phase 4 enforces.
+
+## Common Mistakes
+
+- **Blocking on Phase 2 failure** — `move-issue-status` errors are non-fatal. Log the warning and continue. Never stop the build because of a status update failure.
+- **Omitting the suppression instruction from the Phase 4 prompt** — the verbatim instruction `"Do not invoke finishing-a-development-branch — this will be handled by the calling skill after all review steps complete."` must be included in the execution skill invocation. Paraphrasing it or omitting it is incorrect.
+- **Calling `finishing-a-development-branch` inside the Phase 4 execution skill** — the PR creation step belongs at Phase 10 and only there. The suppression instruction in Phase 4 enforces this; do not override it.
+- **Choosing `subagent-driven-development` for moderate-scope plans** — the default is `executing-plans`. Only switch to `subagent-driven-development` when all three conditions (independent tasks, 5+ subsystems, explicitly large/complex scope) are met simultaneously.
+- **Silently skipping Phase 5 or Phase 9** — these are optional phases but must log a named warning when skipped. Do not silently continue without the warning.
+- **Passing the full raw comment body to `writing-plans`** — strip the `<!-- brainstorming-gh-issue:spec -->` marker line before passing the spec body. Do not include the marker in the context.
+- **Not stripping the leading `#` from the issue number** — `gh issue view` requires a bare integer. Strip any `#` prefix before constructing the command.
+- **Using MCP tools for issue operations** — all GitHub interactions must use `gh` CLI commands. Never call `mcp__plugin_github_github__*` tools for any operation.
+- **Proceeding past Phase 3 before a plan is approved** — `writing-plans` includes a user-approval loop. Wait for approval before executing. Do not skip into Phase 4 on the first plan draft.
+- **Calling `finishing-a-development-branch` more than once** — it must be called exactly once, at Phase 10, regardless of how many execution iterations Phase 4 required.
+
+## Eval
+
+- [ ] Issue number resolved from args (with or without `#` prefix)
+- [ ] Fetched issue with `gh issue view --json number,title,body,comments,labels`
+- [ ] Searched comments for `<!-- brainstorming-gh-issue:spec -->` marker
+- [ ] Blocked with clear error when spec comment not found
+- [ ] Called `token-effort:move-issue-status <N> "Building"` before `writing-plans`
+- [ ] Phase 2 failure logged as a warning and did not block the build
+- [ ] Invoked `superpowers:writing-plans` with spec body as context (marker line stripped)
+- [ ] Waited for plan approval before proceeding to Phase 4
+- [ ] Assessed plan complexity before choosing execution skill
+- [ ] Used `executing-plans` by default; `subagent-driven-development` only when all three conditions apply
+- [ ] Suppression instruction present verbatim in the execution skill invocation prompt
+- [ ] Attempted `/verify` and skipped with named warning if absent
+- [ ] Performed inline simplify pass after verify; reported a summary
+- [ ] Invoked `token-effort:reviewing-code-systematically`
+- [ ] Addressed BLOCK or NEEDS_CHANGES findings before continuing past Phase 7
+- [ ] Performed inline security review after code review; reported a summary
+- [ ] Attempted `token-effort:recording-decisions` and skipped with named warning if absent
+- [ ] Invoked `superpowers:finishing-a-development-branch` exactly once, at Phase 10
+- [ ] `finishing-a-development-branch` was NOT called by the execution skills in Phase 4
+- [ ] No MCP tools used at any point

--- a/plugins/token-effort/skills/move-issue-status/SKILL.md
+++ b/plugins/token-effort/skills/move-issue-status/SKILL.md
@@ -94,7 +94,7 @@ Store as `$OWNER` and `$REPO`. If the command fails or the URL cannot be parsed,
 
 After scanning all projects, you have a list of matching projects (zero, one, or many).
 
-**In explicit mode:** if the list is empty (issue belongs to no project), report an error and stop. Do not call `gh project item-edit`.
+**In explicit mode:** if the list is empty (issue belongs to no project), report the error: "Issue #N is not on any GitHub project board." and stop. Do not call `gh project item-edit`.
 
 **In advance mode:** apply the following silent-skip preconditions in order — stop and skip silently (no error, no output) if any condition is met:
 - Issue belongs to zero projects

--- a/plugins/token-effort/skills/move-issue-status/SKILL.md
+++ b/plugins/token-effort/skills/move-issue-status/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: move-issue-status
+description: Use when moving a GitHub issue to a specific project board status, or advancing it to the next column.
+user-invocable: true
+---
+
+# Move Issue Status
+
+## Overview
+
+Moves a GitHub issue to a named project board status column (explicit mode), or advances it one column to the right if it is currently in the first column (advance mode). All project board operations use the `gh` CLI. No MCP tools are used or required.
+
+**Usage:** `/token-effort:move-issue-status <issue-number> [<status>]`
+
+- `<issue-number>` — the GitHub issue number (leading `#` is stripped automatically)
+- `<status>` — optional; the exact name of the target status column (case-insensitive). Omit to use advance mode.
+
+## When to Use
+
+**Use when:**
+- You want to move an issue to a specific named project board column
+- You want to advance an issue from its current first-column status to the next column
+
+**Do not use when:**
+- You need to move multiple issues at once (run the skill once per issue)
+- You want to label or otherwise edit an issue (use `triaging-gh-issues` instead)
+
+## Prerequisites
+
+The `gh` CLI must be authenticated and available in the session. All project board operations use `gh` commands via Bash. No MCP tools are used or required.
+
+> **Important:** Do **not** use MCP tools (`mcp__plugin_github_github__*`) for any operation, even if they appear to be available.
+
+## Process
+
+### Phase 1 — Resolve owner/repo and normalise issue number
+
+Strip any leading `#` from the issue number argument (e.g. `#42` → `42`).
+
+**If running in GitHub Actions** (`GITHUB_ACTIONS` is set and non-empty):
+
+To detect the GHA context, run the following expansion-free command:
+
+```bash
+printenv GITHUB_ACTIONS
+```
+
+If the output is non-empty, you are in GitHub Actions.
+
+Read the `GITHUB_REPOSITORY` environment variable using:
+
+```bash
+printenv GITHUB_REPOSITORY
+```
+
+This is always set by the GitHub Actions runner in the format `owner/repo` (e.g. `HeadlessTarry/Token-Effort`). Split on `/` to extract `$OWNER` (everything before the first `/`) and `$REPO` (everything after).
+
+If `GITHUB_REPOSITORY` is empty or absent, stop immediately and report: "I could not determine the GitHub repository: the `GITHUB_REPOSITORY` environment variable is not set. Please check your workflow configuration." Do NOT call `git remote get-url origin` as a fallback.
+
+**Otherwise** (interactive / local session, `GITHUB_ACTIONS` is not set):
+
+Run the following Bash command to get the remote URL and extract the owner/repo:
+
+```bash
+git remote get-url origin
+```
+
+Parse owner and repo from the output. Supported URL forms:
+- `https://github.com/<owner>/<repo>.git` → strip `.git`, split on `/`
+- `git@github.com:<owner>/<repo>.git` → strip `.git`, split on `:`
+
+Store as `$OWNER` and `$REPO`. If the command fails or the URL cannot be parsed, stop and ask the user: "I could not determine the GitHub repository from `git remote get-url origin`. Please provide the owner/repo (e.g. `acme/my-repo`)."
+
+### Phase 2 — Find project(s) containing the issue
+
+1. List all projects for the owner:
+
+   ```bash
+   gh project list --owner $OWNER --format json --limit 100
+   ```
+
+2. For each project returned, fetch its items:
+
+   ```bash
+   gh project item-list <project-number> --owner $OWNER --format json --limit 1000
+   ```
+
+   Filter items whose `content.number` matches the issue number. For each match, collect:
+   - item ID
+   - project number
+   - project ID
+   - project name
+   - current status name (may be null/empty)
+
+After scanning all projects, you have a list of matching projects (zero, one, or many).
+
+**In explicit mode:** if the list is empty (issue belongs to no project), report an error and stop. Do not call `gh project item-edit`.
+
+**In advance mode:** apply the following silent-skip preconditions in order — stop and skip silently (no error, no output) if any condition is met:
+- Issue belongs to zero projects
+- Issue belongs to more than one project
+
+### Phase 3 — Determine the target status
+
+#### Explicit mode (`<status>` was provided)
+
+Fetch the fields for the project that contains the issue:
+
+```bash
+gh project field-list <project-number> --owner $OWNER --format json
+```
+
+Find the field named `Status` with type `single_select`. Its `options` array contains the available status values in display order.
+
+- If no `Status` field exists → report an error and stop.
+- Search `options` for an entry whose `name` matches `<status>` using a case-insensitive comparison.
+- If no matching option is found → report an error that includes the list of available option names and stop.
+- If a match is found → record the option's `id` as the target option ID.
+
+#### Advance mode (`<status>` was omitted)
+
+Fetch the fields for the project that contains the issue:
+
+```bash
+gh project field-list <project-number> --owner $OWNER --format json
+```
+
+Find the field named `Status` with type `single_select`. Apply the following silent-skip preconditions in order:
+
+- If no `Status` field exists → skip silently.
+- If the issue's current status (from Phase 2) is null or empty → skip silently.
+- Find the index of the current status name in the `options` array.
+  - If the current status name is not found in the array → skip silently.
+  - If `current_index > 0` (issue is NOT in the first column) → skip silently.
+  - If the current status is the last option (no `options[current_index + 1]` exists) → skip silently.
+- Otherwise, the target option is `options[current_index + 1]`. Record its `id` as the target option ID.
+
+### Phase 4 — Apply and report
+
+Run the following command to move the item:
+
+```bash
+gh project item-edit --project-id <project-id> --id <item-id> --field-id <status-field-id> --single-select-option-id <target-option-id>
+```
+
+- **Success:** report "Moved issue #N to '<target-status-name>' in project '<project-name>'"
+- **Failure:** report the `gh` error message clearly and stop.
+
+## Common Mistakes
+
+- **Using shell expansion syntax** — never use `${VAR}`, `${VAR:-}`, or any `${...}` form in bash commands. Claude Code's sandbox blocks these with a "Contains expansion" error. Always use `printenv VARIABLE` instead.
+- **Treating advance mode and explicit mode identically** — explicit mode moves the issue regardless of its current column position; advance mode has strict preconditions that must all pass before any write occurs.
+- **Calling `gh project item-edit` in advance mode when issue is not at the first column** — if `current_index > 0`, skip silently.
+- **Calling `gh project item-edit` when issue belongs to multiple projects in advance mode** — skip silently when more than one project contains the issue.
+- **Hardcoding status names** — do not hardcode the target status name. Always look up options from the `Status` field's `options` array and advance by index.
+- **Hardcoding the project number** — always derive the project number from `gh project list` and `gh project item-list` lookups.
+- **Skipping the project list lookup** — do not assume a project number or project ID. Run Phase 2 in full for every invocation.
+- **Using MCP tools for any operation** — all interactions with GitHub (issues, projects, fields) must use `gh` CLI commands. Never call any `mcp__` tool.
+- **Reporting an error for advance-mode precondition failures** — when a silent-skip precondition is met in advance mode, produce no output and stop quietly. Reserve errors for explicit mode failures.
+- **Calling `gh project item-edit` when the issue has no current status set (advance mode)** — if the item's status is null or empty, skip silently.
+- **Calling `gh project item-edit` when the issue is already at the last column (advance mode)** — if no `options[current_index + 1]` exists, skip silently.
+- **Calling `gh project item-edit` when issue belongs to zero projects in advance mode** — skip silently; do not report an error.
+- **Performing a case-sensitive match on status names in explicit mode** — the `<status>` argument must be matched case-insensitively against the `options` array.
+
+## Eval
+
+- [ ] Leading `#` stripped from issue number if present
+- [ ] Owner/repo resolved correctly (GHA vs interactive)
+- [ ] `gh project list` and `gh project item-list` used to find the project(s)
+- [ ] In advance mode: execution stopped silently when issue belongs to zero projects
+- [ ] In advance mode: execution stopped silently when issue belongs to more than one project
+- [ ] In advance mode: execution stopped silently when current status is null/empty
+- [ ] In advance mode: execution stopped silently when current status is NOT at index 0
+- [ ] In advance mode: execution stopped silently when current status is the last option
+- [ ] In advance mode: `gh project item-edit` called with options[current_index + 1]
+- [ ] In explicit mode: Status field options fetched and searched by name (case-insensitive)
+- [ ] In explicit mode: error reported if named status option not found
+- [ ] In explicit mode: `gh project item-edit` called regardless of current column position
+- [ ] Success message includes issue number, status name, and project name
+- [ ] No MCP tools used
+- [ ] No `${...}` shell expansion used

--- a/plugins/token-effort/skills/triaging-gh-issues/SKILL.md
+++ b/plugins/token-effort/skills/triaging-gh-issues/SKILL.md
@@ -243,49 +243,13 @@ Triage complete:
 
 **This phase only runs when `--advance-status` was passed at invocation.** If it was not passed, skip this phase entirely.
 
-For **every** classified issue where **confidence > 80%** — regardless of action (`apply`, `reclassify`, or `no-change`) — advance its GitHub project status one column to the right:
+For **every** classified issue where **confidence > 80%** — regardless of action (`apply`, `reclassify`, or `no-change`) — advance its GitHub project status one column to the right by invoking:
 
-1. List all projects for the owner:
+```
+token-effort:move-issue-status <issue-number>
+```
 
-   ```bash
-   gh project list --owner $OWNER --format json --limit 100
-   ```
-
-2. For each project returned, check whether the issue appears in it:
-
-   ```bash
-   gh project item-list <project-number> --owner $OWNER --format json --limit 1000
-   ```
-
-   Filter items whose `content.number` matches the issue number. Collect the matching item IDs, project numbers, **and the item's current `status` name**.
-
-3. Count how many projects contain this issue:
-   - **Zero** → skip silently. Do not call `gh project item-edit`.
-   - **More than one** → skip silently. Do not call `gh project item-edit`.
-   - **Exactly one** → continue to step 4.
-
-4. Get the fields for that project to determine the next status option:
-
-   ```bash
-   gh project field-list <project-number> --owner $OWNER --format json
-   ```
-
-   Find the field named `Status` with type `single_select`. Its `options` array is in board-display order (left to right).
-
-   - If no Status field exists → skip silently. Do not call `gh project item-edit`.
-   - If the issue's current status (from step 2) is null/empty → skip silently. Do not call `gh project item-edit`.
-   - Find the index of the current status name in the `options` array. If not found → skip silently.
-   - If the current status is the **last** option (no next column exists) → skip silently. Do not call `gh project item-edit`.
-   - If the current status is **not** the first option (index > 0) → skip silently. Do not call `gh project item-edit`.
-   - Otherwise, the target option is `options[current_index + 1]`.
-
-5. Update the project item to the next status option:
-
-   ```bash
-   gh project item-edit --project-id <project-id> --id <item-id> --field-id <status-field-id> --single-select-option-id <next-option-id>
-   ```
-
-If any `gh project` call fails for an individual issue, skip that issue's project status update and continue — do not abort the batch.
+No explicit status argument is passed; this uses advance mode. The skill handles all preconditions (single-project membership, first-column check, null status check, last-column check) internally and skips silently if any condition is not met.
 
 > **Confidence threshold:** Only issues with confidence **strictly greater than 80%** trigger the project status update. Issues with confidence ≤ 80% skip Phase 6b entirely, even if they belong to exactly one project. This applies equally to `apply`, `reclassify`, and `no-change` issues.
 
@@ -307,14 +271,9 @@ If any `gh project` call fails for an individual issue, skip that issue's projec
 - **Prompting for confirmation when there is nothing to confirm** — if all issues resolved to `no-change`, skip Phase 5 entirely. Do not display an empty summary table or ask the user to confirm a list with zero changes.
 - **Using MCP tools for issue operations** — all issue interactions (listing, searching, writing labels, posting comments) must use `gh` CLI commands. Never call `mcp__plugin_github_github__list_issues`, `mcp__plugin_github_github__issue_read`, `mcp__plugin_github_github__search_issues`, `mcp__plugin_github_github__issue_write`, `mcp__plugin_github_github__add_issue_comment`, or any other `mcp__` tool for issue operations.
 - **Omitting the Confidence column from the summary table** — the triage summary table must always include a `Confidence` column showing the % value for each `apply` or `reclassify` issue.
-- **Updating project status for low-confidence issues** — `gh project item-edit` must NOT be called for issues with confidence ≤ 80%, even if they belong to exactly one project.
-- **Calling `gh project item-edit` when issue belongs to zero or multiple projects** — skip silently when the issue count is not exactly one.
+- **Updating project status for low-confidence issues** — `token-effort:move-issue-status` must NOT be called for issues with confidence ≤ 80%. Only invoke it when confidence is strictly greater than 80%.
 - **Skipping the project status update for `no-change` issues** — Phase 6b applies to ALL classified issues with confidence > 80%, not just `apply` and `reclassify`. A `no-change` issue with high confidence should still have its project status advanced.
-- **Calling `gh project item-edit` when the issue has no current status set** — if the item's `status` field is null/empty, skip silently. Do not call `gh project item-edit`.
-- **Calling `gh project item-edit` when the issue is already at the last column** — if the current status is the last option in the `options` array, there is no next column. Skip silently.
-- **Setting a hardcoded target status name** — do not look for a specific option by name. Always determine the target by finding the current status index and advancing to `options[index + 1]`.
-- **Updating project status when `--advance-status` was not specified** — Phase 6b must be skipped entirely unless `--advance-status` was passed at invocation. Do not call any `gh project` commands if the flag is absent.
-- **Calling `gh project item-edit` when the issue is not in the first column** — the status may only be advanced when the issue's current status is the first option (index 0) in the Status field options array. Issues already past the first column must be skipped silently.
+- **Updating project status when `--advance-status` was not specified** — Phase 6b must be skipped entirely unless `--advance-status` was passed at invocation. Do not invoke `token-effort:move-issue-status` if the flag is absent.
 
 ## Eval
 
@@ -345,11 +304,6 @@ If any `gh project` call fails for an individual issue, skip that issue's projec
 - [ ] Each `gh issue edit` or `gh issue comment` failure was reported individually without aborting the remaining batch
 - [ ] Final summary reported counts for: labels applied (new), labels updated (reclassified), issues unchanged, and failures
 - [ ] No `mcp__` tool was called at any point
-- [ ] If `--advance-status` was not specified, Phase 6b was skipped entirely — no `gh project` commands were called
-- [ ] For issues with confidence > 80% belonging to exactly one GitHub project whose current status is the first option (index 0) and `--advance-status` was specified: `gh project list`, `gh project item-list`, `gh project field-list`, and `gh project item-edit` were called — this applies to `apply`, `reclassify`, AND `no-change` issues
-- [ ] `gh project item-edit` was NOT called for issues with confidence ≤ 80%
-- [ ] `gh project item-edit` was NOT called when the issue belonged to zero or more than one GitHub project
-- [ ] `gh project item-edit` was NOT called when the issue had no current status set in the project
-- [ ] `gh project item-edit` was NOT called when the issue's current status was the last option in the Status field
-- [ ] `gh project item-edit` was NOT called when the issue's current status was not the first option (index > 0) in the Status field
-- [ ] The target status was determined by advancing one position in the ordered `options` array — not by searching for a hardcoded name
+- [ ] If `--advance-status` was not specified, Phase 6b was skipped entirely — `token-effort:move-issue-status` was NOT called
+- [ ] `token-effort:move-issue-status <N>` (no explicit status) was called for each classified issue with confidence > 80%, regardless of action (`apply`, `reclassify`, or `no-change`)
+- [ ] `token-effort:move-issue-status` was NOT called for issues with confidence ≤ 80%

--- a/training/skills/build/blocks-without-spec-comment.md
+++ b/training/skills/build/blocks-without-spec-comment.md
@@ -1,0 +1,20 @@
+## Scenario
+
+The user runs `/token-effort:build 15`. The issue exists and has 2 comments, but neither comment starts with `<!-- brainstorming-gh-issue:spec -->`. No spec has been produced for this issue yet.
+
+## Expected Behaviour
+
+- Phase 1 fetches the issue and searches all comments for a `<!-- brainstorming-gh-issue:spec -->` marker.
+- No comment with that marker is found.
+- Execution stops immediately with a clear error message telling the user to run `/token-effort:brainstorming-gh-issue 15` first.
+- No subsequent phases (move-issue-status, writing-plans, etc.) run.
+
+## Pass Criteria
+
+- [ ] `gh issue view 15 --json number,title,body,comments,labels` (or equivalent) is called.
+- [ ] All comments are searched for the `<!-- brainstorming-gh-issue:spec -->` marker.
+- [ ] No spec comment is found and execution halts.
+- [ ] The error message includes the issue number (15).
+- [ ] The error message instructs the user to run `/token-effort:brainstorming-gh-issue 15` (or equivalent brainstorming step) first.
+- [ ] `token-effort:move-issue-status` is NOT called.
+- [ ] `superpowers:writing-plans` is NOT called.

--- a/training/skills/build/calls-move-issue-status-building.md
+++ b/training/skills/build/calls-move-issue-status-building.md
@@ -1,0 +1,17 @@
+## Scenario
+
+The user runs `/token-effort:build 22`. The issue has a valid spec comment whose first line is `<!-- brainstorming-gh-issue:spec -->` followed by the full spec body. The issue is on a project board.
+
+## Expected Behaviour
+
+- Phase 1 fetches the issue, finds the spec comment, and strips the `<!-- brainstorming-gh-issue:spec -->` marker line from the body before storing the spec.
+- Phase 2 calls `token-effort:move-issue-status 22 "Building"` before invoking `superpowers:writing-plans`.
+- Phase 3 invokes `superpowers:writing-plans` with the stripped spec body (marker line absent).
+
+## Pass Criteria
+
+- [ ] `gh issue view 22 --json number,title,body,comments,labels` (or equivalent) is called.
+- [ ] The spec comment is found via its `<!-- brainstorming-gh-issue:spec -->` marker.
+- [ ] `token-effort:move-issue-status 22 "Building"` is called.
+- [ ] `superpowers:writing-plans` is called AFTER `token-effort:move-issue-status`.
+- [ ] The spec body passed to `superpowers:writing-plans` does NOT include the `<!-- brainstorming-gh-issue:spec -->` marker line.

--- a/training/skills/build/complexity-default-executing-plans.md
+++ b/training/skills/build/complexity-default-executing-plans.md
@@ -1,0 +1,17 @@
+## Scenario
+
+The user runs `/token-effort:build 55`. A valid spec comment exists. The plan produced by `superpowers:writing-plans` covers 2 subsystems with mostly sequential steps — moderate scope, not explicitly designated large or complex.
+
+## Expected Behaviour
+
+- After `writing-plans` returns the plan, the skill assesses plan complexity.
+- The plan is determined to be moderate scope (fewer than 5 subsystems, no large-scope designation).
+- `superpowers:executing-plans` is chosen for Phase 4.
+- `superpowers:subagent-driven-development` is NOT invoked.
+
+## Pass Criteria
+
+- [ ] Plan complexity is assessed before Phase 4 begins.
+- [ ] Plan is determined to be moderate scope (fewer than 5 subsystems, no explicit large-scope designation).
+- [ ] `superpowers:executing-plans` is invoked for Phase 4.
+- [ ] `superpowers:subagent-driven-development` is NOT invoked.

--- a/training/skills/build/skips-verify-with-warning.md
+++ b/training/skills/build/skips-verify-with-warning.md
@@ -1,0 +1,16 @@
+## Scenario
+
+The user runs `/token-effort:build 44`. A valid spec comment exists and the plan executes successfully through Phase 4. In Phase 5, the skill attempts to invoke `/verify`, but the skill is not available in this project.
+
+## Expected Behaviour
+
+- Phase 5 attempts to invoke `/verify`.
+- Because `/verify` is unavailable, a named warning is logged: "⚠️ Phase 5 skipped: `/verify` skill not available in this project".
+- Execution continues without stopping; Phase 6 (inline simplify pass) runs next.
+
+## Pass Criteria
+
+- [ ] An attempt to invoke `/verify` is made in Phase 5.
+- [ ] A named warning is logged that includes both "Phase 5 skipped" and "/verify".
+- [ ] Execution does NOT stop or error out after the warning.
+- [ ] Phase 6 (inline simplify pass) runs after the warning is logged.

--- a/training/skills/build/suppresses-finishing-branch.md
+++ b/training/skills/build/suppresses-finishing-branch.md
@@ -1,0 +1,16 @@
+## Scenario
+
+The user runs `/token-effort:build 31`. A valid spec comment exists on the issue. The plan produced by `superpowers:writing-plans` is moderate in scope — it covers one subsystem with a few sequential steps — and the skill selects `superpowers:executing-plans` for Phase 4.
+
+## Expected Behaviour
+
+- Phase 4 invokes `superpowers:executing-plans` with the verbatim suppression instruction embedded in the prompt: "Do not invoke `finishing-a-development-branch` — this will be handled by the calling skill after all review steps complete."
+- `executing-plans` respects the suppression and does NOT call `superpowers:finishing-a-development-branch` internally.
+- `superpowers:finishing-a-development-branch` is called exactly once, at Phase 10, after all review steps complete.
+
+## Pass Criteria
+
+- [ ] `superpowers:executing-plans` is chosen for Phase 4 (not `superpowers:subagent-driven-development`).
+- [ ] The invocation prompt for `superpowers:executing-plans` contains the exact text: "Do not invoke `finishing-a-development-branch` — this will be handled by the calling skill after all review steps complete."
+- [ ] `superpowers:finishing-a-development-branch` is NOT called during or inside Phase 4.
+- [ ] `superpowers:finishing-a-development-branch` is called exactly once, at Phase 10.

--- a/training/skills/move-issue-status/advance-skips-multiple-projects.md
+++ b/training/skills/move-issue-status/advance-skips-multiple-projects.md
@@ -1,0 +1,18 @@
+## Scenario
+
+The user runs `/token-effort:move-issue-status 33` (advance mode — no status argument). Issue #33 appears in two different project boards.
+
+## Expected Behaviour
+
+- The skill retrieves the project list and queries each project for issue #33.
+- It finds issue #33 in more than one project.
+- Because the multiple-projects skip condition is met, the skill exits silently: no output, no error, and no `gh project item-edit` call is made.
+
+## Pass Criteria
+
+- [ ] `gh project list` is called to enumerate projects.
+- [ ] `gh project item-list` is called for each project to search for issue #33.
+- [ ] Issue #33 is found in more than one project.
+- [ ] `gh project item-edit` is NOT called.
+- [ ] No error message is shown.
+- [ ] No output of any kind is produced.

--- a/training/skills/move-issue-status/advance-skips-non-first-column.md
+++ b/training/skills/move-issue-status/advance-skips-non-first-column.md
@@ -1,0 +1,19 @@
+## Scenario
+
+The user runs `/token-effort:move-issue-status 17` (advance mode — no status argument). Issue #17 is on exactly one project board, currently in the "Building" column (index 1, not the first column).
+
+## Expected Behaviour
+
+- The skill retrieves the project list and finds exactly one project containing issue #17.
+- It determines the current Status column index for issue #17.
+- Because the current column index is greater than 0 (it is not the first column), the skip condition is met.
+- The skill exits silently: no output, no error, and no `gh project item-edit` call is made.
+
+## Pass Criteria
+
+- [ ] `gh project list` is called to enumerate projects.
+- [ ] `gh project item-list` is called to locate issue #17 in the project.
+- [ ] The current status index is determined to be greater than 0.
+- [ ] `gh project item-edit` is NOT called.
+- [ ] No error message is shown.
+- [ ] No output of any kind is produced.

--- a/training/skills/move-issue-status/explicit-status-applied.md
+++ b/training/skills/move-issue-status/explicit-status-applied.md
@@ -1,0 +1,22 @@
+## Scenario
+
+The user runs `/token-effort:move-issue-status 42 "Building"`. Issue #42 is on exactly one project board. Its current Status column is "Triaged" (index 1). The "Building" option exists in the project's Status field.
+
+## Expected Behaviour
+
+- The skill retrieves the list of projects and finds exactly one project containing issue #42.
+- It fetches the project's field list and locates the Status field with all available options.
+- It matches "Building" case-insensitively against the available options.
+- It calls `gh project item-edit` with the correct item ID, field ID, and "Building" option ID.
+- It does not check or care that the current column is not index 0 — explicit mode always applies the named status.
+- A success message is shown including the issue number, the status name applied, and the project name.
+
+## Pass Criteria
+
+- [ ] `gh project list` is called to enumerate projects.
+- [ ] `gh project item-list` is called to find issue #42 in the project.
+- [ ] `gh project field-list` is called to retrieve Status field options.
+- [ ] "Building" is matched case-insensitively against the available status options.
+- [ ] `gh project item-edit` is called with the correct option ID for "Building".
+- [ ] The success message includes the issue number (42), the status name ("Building"), and the project name.
+- [ ] The current column position ("Triaged", index 1) did NOT prevent the update.

--- a/training/skills/move-issue-status/explicit-status-no-board.md
+++ b/training/skills/move-issue-status/explicit-status-no-board.md
@@ -1,0 +1,19 @@
+## Scenario
+
+The user runs `/token-effort:move-issue-status 99 "In Progress"` (explicit mode). Issue #99 does not appear in any project board.
+
+## Expected Behaviour
+
+- The skill retrieves the project list and queries each project for issue #99.
+- No project contains issue #99.
+- The skill reports a clear error message stating that issue #99 was not found on any project board.
+- Execution stops immediately after the error. No `gh project item-edit` call is made.
+
+## Pass Criteria
+
+- [ ] `gh project list` is called to enumerate projects.
+- [ ] `gh project item-list` is called to search for issue #99 across projects.
+- [ ] Zero matching projects are found.
+- [ ] `gh project item-edit` is NOT called.
+- [ ] A clear error message is reported that names the issue number (99).
+- [ ] Execution stops after the error with no further steps attempted.


### PR DESCRIPTION
Closes #50

## Summary

- **New skill: `token-effort:build`** — 10-phase end-to-end orchestrator. Accepts an issue number, validates a `<!-- brainstorming-gh-issue:spec -->` comment exists, then drives the full workflow: move to Building → write plan → execute → verify → simplify → code review → security review → record decisions → create PR. Optional phases (verify, recording-decisions) degrade gracefully with named warnings.
- **New skill: `token-effort:move-issue-status`** — reusable helper extracted from `triaging-gh-issues` Phase 6b. Supports explicit mode (move to named column) and advance mode (move to next column from index 0), with full precondition handling.
- **Updated: `triaging-gh-issues`** — Phase 6b now delegates to `token-effort:move-issue-status` instead of inlining `gh project` commands. Common Mistakes and Eval sections updated accordingly.
- **Training evals** — 4 evals for `move-issue-status`, 5 evals for `build`.

## Test Plan

- [ ] Run `/token-effort:build <N>` on an issue without a spec comment — confirm it blocks with the correct error
- [ ] Run `/token-effort:build <N>` on an issue with a valid spec comment — confirm Phase 2 calls `move-issue-status <N> "Building"` and Phase 3 invokes `writing-plans`
- [ ] Run `/token-effort:move-issue-status <N> "Building"` on an issue on a project board — confirm status is updated
- [ ] Run `/triaging-gh-issues --advance-status` — confirm `move-issue-status` is called for qualifying issues instead of inline `gh project` commands
- [ ] Run `pytest tests/` — 12/12 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)