### PR TITLE
fix: allow Skill tool and clarify --advance-status in triage workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         id: release-manager-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_MANAGER_APP_ID }}
+          client-id: ${{ vars.RELEASE_MANAGER_APP_ID }}
           private-key: ${{ secrets.RELEASE_MANAGER_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}

--- a/.github/workflows/triaging-gh-issues.yml
+++ b/.github/workflows/triaging-gh-issues.yml
@@ -37,4 +37,3 @@ jobs:
           claude_args: >-
             --model sonnet
             --allowedTools Skill,Bash(printenv *),Bash(git remote get-url *),Bash(gh issue list *),Bash(gh issue view *),Bash(gh search issues *),Bash(gh issue edit *),Bash(gh issue comment *),Bash(gh project list *),Bash(gh project item-list *),Bash(gh project field-list *),Bash(gh project item-edit *)
-          show_full_output: true

--- a/.github/workflows/triaging-gh-issues.yml
+++ b/.github/workflows/triaging-gh-issues.yml
@@ -30,10 +30,10 @@ jobs:
           plugin_marketplaces: https://github.com/HeadlessTarry/Token-Effort.git
           plugins: token-effort
           prompt: |
-            Use the `token-effort:triaging-gh-issues` skill.
-            --advance-status Triage all open issues in this repository.
+            Use the `token-effort:triaging-gh-issues` skill with `--advance-status`.
+            Triage all open issues in this repository.
 
             Upon completion, write a brief markdown summary of your activity to the GitHub Actions step summary using: SUMMARY_FILE=$(printenv GITHUB_STEP_SUMMARY) && echo "**[Claude]** {Activity summary}" >> "$SUMMARY_FILE"
           claude_args: >-
             --model haiku
-            --allowedTools Bash(printenv *),Bash(git remote get-url *),Bash(gh issue list *),Bash(gh issue view *),Bash(gh search issues *),Bash(gh issue edit *),Bash(gh issue comment *),Bash(gh project list *),Bash(gh project item-list *),Bash(gh project field-list *),Bash(gh project item-edit *)
+            --allowedTools Skill,Bash(printenv *),Bash(git remote get-url *),Bash(gh issue list *),Bash(gh issue view *),Bash(gh search issues *),Bash(gh issue edit *),Bash(gh issue comment *),Bash(gh project list *),Bash(gh project item-list *),Bash(gh project field-list *),Bash(gh project item-edit *)

--- a/.github/workflows/triaging-gh-issues.yml
+++ b/.github/workflows/triaging-gh-issues.yml
@@ -37,3 +37,4 @@ jobs:
           claude_args: >-
             --model haiku
             --allowedTools Skill,Bash(printenv *),Bash(git remote get-url *),Bash(gh issue list *),Bash(gh issue view *),Bash(gh search issues *),Bash(gh issue edit *),Bash(gh issue comment *),Bash(gh project list *),Bash(gh project item-list *),Bash(gh project field-list *),Bash(gh project item-edit *)
+          show_full_output: true

--- a/.github/workflows/triaging-gh-issues.yml
+++ b/.github/workflows/triaging-gh-issues.yml
@@ -17,7 +17,7 @@ jobs:
         id: project-manager-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PROJECT_MANAGER_APP_ID }}
+          client-id: ${{ vars.PROJECT_MANAGER_APP_ID }}
           private-key: ${{ secrets.PROJECT_MANAGER_PRIVATE_KEY }}
           # Obtain a token with access to the owner-level resources (i.e. GH projects)
           owner: ${{ github.repository_owner }}

--- a/.github/workflows/triaging-gh-issues.yml
+++ b/.github/workflows/triaging-gh-issues.yml
@@ -35,6 +35,6 @@ jobs:
 
             Upon completion, write a brief markdown summary of your activity to the GitHub Actions step summary using: SUMMARY_FILE=$(printenv GITHUB_STEP_SUMMARY) && echo "**[Claude]** {Activity summary}" >> "$SUMMARY_FILE"
           claude_args: >-
-            --model haiku
+            --model sonnet
             --allowedTools Skill,Bash(printenv *),Bash(git remote get-url *),Bash(gh issue list *),Bash(gh issue view *),Bash(gh search issues *),Bash(gh issue edit *),Bash(gh issue comment *),Bash(gh project list *),Bash(gh project item-list *),Bash(gh project field-list *),Bash(gh project item-edit *)
           show_full_output: true

--- a/plugins/token-effort/skills/triaging-gh-issues/SKILL.md
+++ b/plugins/token-effort/skills/triaging-gh-issues/SKILL.md
@@ -243,11 +243,14 @@ Triage complete:
 
 **This phase only runs when `--advance-status` was passed at invocation.** If it was not passed, skip this phase entirely.
 
-For **every** classified issue where **confidence > 80%** — regardless of action (`apply`, `reclassify`, or `no-change`) — advance its GitHub project status one column to the right by invoking:
+For **every** classified issue where **confidence > 80%** — regardless of action (`apply`, `reclassify`, or `no-change`) — advance its GitHub project status one column to the right. Process each issue **one at a time** in the following sequence:
 
-```
-token-effort:move-issue-status <issue-number>
-```
+1. Invoke the `token-effort:move-issue-status` skill using the Skill tool:
+   ```
+   token-effort:move-issue-status <issue-number>
+   ```
+2. The skill will return detailed instructions. **Execute every phase those instructions describe** — including all `gh project` Bash commands (`gh project list`, `gh project item-list`, `gh project field-list`, `gh project item-edit`) — before moving on to the next issue.
+3. Do not call the Skill tool for the next issue until the current issue's execution is fully complete (all phases run, result reported).
 
 No explicit status argument is passed; this uses advance mode. The skill handles all preconditions (single-project membership, first-column check, null status check, last-column check) internally and skips silently if any condition is not met.
 
@@ -274,6 +277,7 @@ No explicit status argument is passed; this uses advance mode. The skill handles
 - **Updating project status for low-confidence issues** — `token-effort:move-issue-status` must NOT be called for issues with confidence ≤ 80%. Only invoke it when confidence is strictly greater than 80%.
 - **Skipping the project status update for `no-change` issues** — Phase 6b applies to ALL classified issues with confidence > 80%, not just `apply` and `reclassify`. A `no-change` issue with high confidence should still have its project status advanced.
 - **Updating project status when `--advance-status` was not specified** — Phase 6b must be skipped entirely unless `--advance-status` was passed at invocation. Do not invoke `token-effort:move-issue-status` if the flag is absent.
+- **Batch-calling `token-effort:move-issue-status` for multiple issues without executing each sub-skill's phases** — for each issue, call the Skill tool, then execute every phase the returned skill describes (including all `gh project` Bash commands), before invoking the skill for the next issue. Do not make multiple Skill tool calls in succession without executing the returned instructions first.
 
 ## Eval
 
@@ -306,4 +310,5 @@ No explicit status argument is passed; this uses advance mode. The skill handles
 - [ ] No `mcp__` tool was called at any point
 - [ ] If `--advance-status` was not specified, Phase 6b was skipped entirely — `token-effort:move-issue-status` was NOT called
 - [ ] `token-effort:move-issue-status <N>` (no explicit status) was called for each classified issue with confidence > 80%, regardless of action (`apply`, `reclassify`, or `no-change`)
+- [ ] Each invocation of `token-effort:move-issue-status` completed in full (all phases executed, including all `gh project` Bash commands) before the skill was invoked for the next issue
 - [ ] `token-effort:move-issue-status` was NOT called for issues with confidence ≤ 80%

--- a/training/skills/triaging-gh-issues/phase6b-completes-execution-before-next-issue.md
+++ b/training/skills/triaging-gh-issues/phase6b-completes-execution-before-next-issue.md
@@ -1,0 +1,26 @@
+## Scenario
+
+GHA context (`GITHUB_ACTIONS=true`, `GITHUB_REPOSITORY=HeadlessTarry/Token-Effort`). Invoked with `--advance-status`. Two unlabelled open issues:
+
+- Issue #20 — "Button click handler throws TypeError" → `bug`, confidence 95%
+- Issue #21 — "Add CSV export to reports page" → `enhancement`, confidence 89%
+
+Both issues belong to exactly one GitHub project (project number 2, "Backlog"). `gh project item-list` shows both have a current status of "New". `gh project field-list` shows the Status field options in order: "New", "In Progress", "Done".
+
+## Expected Behaviour
+
+- Issue #20 is classified as `bug`, labelled via `gh issue edit --add-label bug`.
+- `gh project item-edit` is called for issue #20, advancing its status to "In Progress".
+- Only after issue #20's project status is advanced does the skill proceed to issue #21.
+- Issue #21 is classified as `enhancement`, labelled via `gh issue edit --add-label enhancement`.
+- `gh project item-edit` is called for issue #21, advancing its status to "In Progress".
+- Final report shows 2 applied, 0 reclassified, 0 unchanged, 0 failures.
+
+## Pass Criteria
+
+- [ ] `gh issue edit --add-label bug` is called for issue #20.
+- [ ] `gh issue edit --add-label enhancement` is called for issue #21.
+- [ ] `gh project item-edit` is called for issue #20 before any processing of issue #21 begins.
+- [ ] `gh project item-edit` is called for issue #21.
+- [ ] `gh project item-edit` is called exactly twice total.
+- [ ] Final report shows 2 applied, 0 reclassified, 0 unchanged, 0 failures.

--- a/training/skills/triaging-gh-issues/phase6b-multi-issue-all-statuses-advanced.md
+++ b/training/skills/triaging-gh-issues/phase6b-multi-issue-all-statuses-advanced.md
@@ -1,0 +1,29 @@
+## Scenario
+
+GHA context (`GITHUB_ACTIONS=true`, `GITHUB_REPOSITORY=HeadlessTarry/Token-Effort`). Invoked with `--advance-status`. Three unlabelled open issues all receive unambiguous classifications with confidence above 80%:
+
+- Issue #10 — "App crashes with NullPointerException on startup" → `bug`, confidence 97%
+- Issue #11 — "Add dark mode toggle to settings" → `enhancement`, confidence 91%
+- Issue #12 — "Typo in README contributing section" → `documentation`, confidence 88%
+
+All three issues belong to exactly one GitHub project (project number 1, "Roadmap"). `gh project item-list` shows each has a current status of "New". `gh project field-list` shows the Status field options in order: "New", "Brainstorming", "Building", "Done".
+
+## Expected Behaviour
+
+- All three issues are labelled via `gh issue edit --add-label`.
+- For each issue, the project status is advanced one column:
+  - `gh project list` is called (once is sufficient to discover projects).
+  - `gh project item-list` is called to locate each issue and read its current status.
+  - `gh project field-list` is called to get the ordered Status options.
+  - `gh project item-edit` is called to set each issue's status to "Brainstorming".
+- The model does not move on to the next issue until the `gh project item-edit` call for the current issue is complete.
+- Final report shows 3 applied, 0 reclassified, 0 unchanged, 0 failures.
+
+## Pass Criteria
+
+- [ ] `gh issue edit --add-label` is called for each of issues #10, #11, and #12.
+- [ ] `gh project list` is called at least once to discover projects.
+- [ ] `gh project item-list` is called to locate all three issues.
+- [ ] `gh project field-list` is called to retrieve Status field options.
+- [ ] `gh project item-edit` is called exactly three times — once per issue — to advance each to the next status option.
+- [ ] Final report shows 3 applied, 0 reclassified, 0 unchanged, 0 failures.


### PR DESCRIPTION
## Summary

- Add `Skill` to `--allowedTools` in the triage workflow — it was missing, which silently blocked all `token-effort:move-issue-status` calls in Phase 6b (GitHub Actions has no user present to approve unlisted tools)
- Separate `--advance-status` from prose in the prompt so it is unambiguously parsed as a skill argument

## Root cause

The `triaging-gh-issues` skill advances project statuses via the `Skill` tool (`token-effort:move-issue-status`). Because `Skill` was not in `--allowedTools`, every invocation was silently blocked in GHA context, leaving all issues stuck in the "New" column despite Claude reporting success.

Further, the `haiku` model was happy to load the `move-issue-status` skill content, but regularly failed to execute the skill - resulting in the same behaviour of not actually moving the issues along. Upgrading to `sonnet` resolved this.

## Test plan

- [x] Trigger the workflow via `workflow_dispatch` and confirm issues in the "New" column advance to "Brainstorming"
- [x] Confirm the step summary accurately reflects the number of statuses advanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)