### PR TITLE
fix(init-plus): fix lint violations in all generated file templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .worktrees/
 __pycache__/
 *.pyc
+docs/superpowers/

--- a/plugins/token-effort/skills/init-plus/SKILL.md
+++ b/plugins/token-effort/skills/init-plus/SKILL.md
@@ -99,7 +99,9 @@ Create directory `.github/workflows/` if it does not exist.
 Write `.github/workflows/triaging-gh-issues.yml`:
 
 ```yaml
+---
 name: Triage GitHub Issues
+# yamllint disable-line rule:truthy
 on:
   schedule:
     - cron: '0 4 * * 1'
@@ -162,15 +164,21 @@ labels: enhancement
 assignees: ''
 
 ---
-**Is your feature request related to a problem? Please describe.**
+
+## Is your feature request related to a problem? Please describe.
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
-**Describe alternatives you've considered**
+
+## Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Additional context
+
 Add any other context or screenshots about the feature request here.
 ```
 Write `.github/ISSUE_TEMPLATE/02-bug_report.md`:
@@ -182,11 +190,15 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: ''
+
 ---
 
-**Describe the bug**
+## Describe the bug
+
 A clear and concise description of what the bug is.
-**To Reproduce**
+
+## To Reproduce
+
 Steps to reproduce the behavior:
 
 1. Go to '...'
@@ -194,17 +206,22 @@ Steps to reproduce the behavior:
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+## Expected behavior
+
 A clear and concise description of what you expected to happen.
-**Screenshots**
+
+## Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
-**Additional context**
+## Additional context
+
 Add any other context about the problem here.
 ```
 Write `.github/ISSUE_TEMPLATE/config.yml`:
 
 ```yaml
+---
 blank_issues_enabled: false
 ```
 ---
@@ -248,11 +265,14 @@ user-invocable: true
 ---
 
 # Verify
+
 Run all project checks to confirm changes are working correctly.
+
 ## Commands
 
 Run each of the following commands. Report the result of each (pass/fail and any output).
 If any command fails, stop and report the failure. Do not run any remaining commands.
+
 1. `<command 1>`
 2. `<command 2>`
 (Add one line per additional command)


### PR DESCRIPTION
## Summary

- Add YAML document-start markers (`---`) to `triaging-gh-issues.yml` and `config.yml` generated templates
- Add `# yamllint disable-line rule:truthy` before `on:` in the workflow template
- Fix MD022/MD032 blank-line violations in the `verify/SKILL.md` template
- Replace `**bold**` section pseudo-headers with `## ATX headings` in both issue templates

Closes #80

## Test Plan

- [ ] Run `/token-effort:init-plus` on a fresh repo, select steps 3, 4, and 6
- [ ] Run `yamllint .github/workflows/triaging-gh-issues.yml .github/ISSUE_TEMPLATE/config.yml` — expect zero violations
- [ ] Run `markdownlint .github/ISSUE_TEMPLATE/*.md .claude/skills/verify/SKILL.md` — expect zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)