### PR TITLE
fix: init-plus Step 3 uses versioned GitHub URL for docs/github-setup.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,19 @@ jobs:
             exit 1
           fi
 
-      - name: 📝 Patch plugin.json version
+      - name: 📝 Patch plugin.json version and SKILL.md URLs
         run: |
           jq --arg version "$VERSION" '.version = $version' \
             plugins/token-effort/.claude-plugin/plugin.json > plugin.json.tmp
           mv plugin.json.tmp plugins/token-effort/.claude-plugin/plugin.json
           sed -i "s|/blob/v[0-9]*\.[0-9]*\.[0-9]*/docs/github-setup|/blob/v$VERSION/docs/github-setup|g" \
             plugins/token-effort/skills/init-plus/SKILL.md
+          EXPECTED=5
+          ACTUAL=$(grep -c "HeadlessTarry/Token-Effort/blob/v$VERSION/docs/github-setup" plugins/token-effort/skills/init-plus/SKILL.md || true)
+          if [ "$ACTUAL" -ne "$EXPECTED" ]; then
+            echo "Expected $EXPECTED versioned URLs in SKILL.md after sed, found $ACTUAL. Check for unmatched URL formats."
+            exit 1
+          fi
 
       - name: 📝 Commit and push version bump
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,14 @@ jobs:
           jq --arg version "$VERSION" '.version = $version' \
             plugins/token-effort/.claude-plugin/plugin.json > plugin.json.tmp
           mv plugin.json.tmp plugins/token-effort/.claude-plugin/plugin.json
+          sed -i "s|/blob/v[0-9]*\.[0-9]*\.[0-9]*/docs/github-setup|/blob/v$VERSION/docs/github-setup|g" \
+            plugins/token-effort/skills/init-plus/SKILL.md
 
       - name: 📝 Commit and push version bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add plugins/token-effort/.claude-plugin/plugin.json
+          git add plugins/token-effort/.claude-plugin/plugin.json plugins/token-effort/skills/init-plus/SKILL.md
           git diff --cached --quiet || git commit -m "chore: release v$VERSION"
           git push origin HEAD
 

--- a/docs/decisions/2026-04-init-plus-versioned-setup-url.md
+++ b/docs/decisions/2026-04-init-plus-versioned-setup-url.md
@@ -1,0 +1,17 @@
+# 2026-04-init-plus-versioned-setup-url
+
+> **Status:** Active
+> **Issue:** [#78 — C:/Program Files/Git/init-plus Step 3 references docs/github-setup.md as local path instead of live URL](https://github.com/HeadlessTarry/Token-Effort/issues/78)
+> **Date:** 2026-04-19
+
+## 🗂️ Context
+
+The `/init-plus` skill references `docs/github-setup.md` as a bare local path in Step 3. This file exists in the Token-Effort repository but not in the user's repository where `/init-plus` runs. Plugin users see a path that leads nowhere.
+
+## ✅ Decision
+
+Replace all bare `docs/github-setup.md` path references in `plugins/token-effort/skills/init-plus/SKILL.md` with Markdown links pointing to a versioned GitHub URL (e.g. `blob/v0.6.0/docs/github-setup.md`). The release workflow patches these URLs at publish time via a `sed` command, so they always reflect the installed plugin version rather than a floating `main` reference.
+
+## ⚖️ Consequences
+
+Plugin users always see documentation that matches their installed version. Between releases, `main` points to the previous tag's docs — acceptable since those are stable. If a future contributor adds a new reference in a different URL format, the `sed` will silently skip it; a verification step in the release workflow guards against this by asserting the expected URL count after substitution.

--- a/plugins/token-effort/skills/init-plus/SKILL.md
+++ b/plugins/token-effort/skills/init-plus/SKILL.md
@@ -23,6 +23,7 @@ Step 5 (Dependabot) is delegated entirely to `token-effort:configuring-dependabo
 - You only want to configure Dependabot — run `/token-effort:configuring-dependabot` directly instead
 
 ## Prerequisites
+<!-- The version tag in the github-setup.md URLs below is updated automatically by release.yml at publish time. Do not change it manually. -->
 - For Step 3: a GitHub App and project board must be configured — see [docs/github-setup.md](https://github.com/HeadlessTarry/Token-Effort/blob/v0.6.0/docs/github-setup.md)
 - For Step 5: the `token-effort:configuring-dependabot` skill must be installed
 

--- a/plugins/token-effort/skills/init-plus/SKILL.md
+++ b/plugins/token-effort/skills/init-plus/SKILL.md
@@ -23,7 +23,7 @@ Step 5 (Dependabot) is delegated entirely to `token-effort:configuring-dependabo
 - You only want to configure Dependabot — run `/token-effort:configuring-dependabot` directly instead
 
 ## Prerequisites
-- For Step 3: a GitHub App and project board must be configured — see `docs/github-setup.md`
+- For Step 3: a GitHub App and project board must be configured — see [docs/github-setup.md](https://github.com/HeadlessTarry/Token-Effort/blob/v0.6.0/docs/github-setup.md)
 - For Step 5: the `token-effort:configuring-dependabot` skill must be installed
 
 ## Process
@@ -86,11 +86,11 @@ If the user says no or skips, note "Superpowers plugin: not installed (recommend
 **Step 3 — Auto-triage GitHub Actions workflow**
 Print:
 
-> "Step 3 requires a GitHub App and project board. See `docs/github-setup.md` for setup instructions."
+> "Step 3 requires a GitHub App and project board. See [docs/github-setup.md](https://github.com/HeadlessTarry/Token-Effort/blob/v0.6.0/docs/github-setup.md) for setup instructions."
 Ask:
-> "Is everything in `docs/github-setup.md` configured? [yes/no/skip]"
+> "Is everything in [docs/github-setup.md](https://github.com/HeadlessTarry/Token-Effort/blob/v0.6.0/docs/github-setup.md) configured? [yes/no/skip]"
 
-If the user says no or skips, print: "> Complete the setup in `docs/github-setup.md`, then re-run `/token-effort:init-plus` and select Step 3 to continue." Note "Triage workflow: skipped (prerequisites not met)" in the summary and continue to Step 4.
+If the user says no or skips, print: "> Complete the setup in [docs/github-setup.md](https://github.com/HeadlessTarry/Token-Effort/blob/v0.6.0/docs/github-setup.md), then re-run `/token-effort:init-plus` and select Step 3 to continue." Note "Triage workflow: skipped (prerequisites not met)" in the summary and continue to Step 4.
 If `.github/workflows/triaging-gh-issues.yml` exists:
 > "`.github/workflows/triaging-gh-issues.yml` already exists. Overwrite? [yes/no]"
 
@@ -300,7 +300,7 @@ No git commit is made. The user decides what to commit.
 - [ ] Step 1: Did not write `CLAUDE.md` directly or use a hardcoded template
 - [ ] Step 2: Printed superpowers install recommendation with GitHub URL
 - [ ] Step 2: Asked if installed; did not block on "no" or "skip"
-- [ ] Step 3: Referenced `docs/github-setup.md` for prerequisites
+- [ ] Step 3: Referenced [docs/github-setup.md](https://github.com/HeadlessTarry/Token-Effort/blob/v0.6.0/docs/github-setup.md) for prerequisites
 - [ ] Step 3: Asked if prerequisites set up; skipped workflow on "no"/"skip"
 - [ ] Step 3: Warned and confirmed before overwriting existing workflow file
 - [ ] Step 3: Wrote workflow with exact content matching the template above

--- a/training/skills/init-plus/step3-setup-link-is-github-url.md
+++ b/training/skills/init-plus/step3-setup-link-is-github-url.md
@@ -1,4 +1,5 @@
 ## Scenario
+<!-- Covers: SKILL.md "Step 3 — Auto-triage GitHub Actions workflow" prerequisite block -->
 The user selects "3". The skill prints the Step 3 prerequisite message and asks if
 everything is configured.
 

--- a/training/skills/init-plus/step3-setup-link-is-github-url.md
+++ b/training/skills/init-plus/step3-setup-link-is-github-url.md
@@ -1,0 +1,15 @@
+## Scenario
+The user selects "3". The skill prints the Step 3 prerequisite message and asks if
+everything is configured.
+
+## Expected Behavior
+The prerequisite message and the follow-up skip message must reference
+`docs/github-setup.md` as a Markdown link pointing to
+`https://github.com/HeadlessTarry/Token-Effort/` — not as a bare local path or
+backtick-quoted filename. The specific version tag in the URL may vary across
+releases and is not checked.
+
+## Pass Criteria
+- [ ] The prerequisite message contains a Markdown link whose URL starts with `https://github.com/HeadlessTarry/Token-Effort/`
+- [ ] The prerequisite message does NOT present `docs/github-setup.md` as a bare backtick-quoted local path
+- [ ] The follow-up skip message (printed when the user says no/skip) also uses a GitHub URL link, not a bare path


### PR DESCRIPTION
## Summary

- Replaces bare `docs/github-setup.md` local path references in `init-plus/SKILL.md` with Markdown links pointing to a versioned GitHub URL (`blob/v0.6.0/docs/github-setup.md`)
- Extends the release workflow to patch these URLs via `sed` at publish time, keeping them in sync with the installed plugin version
- Adds a post-`sed` verification step that fails the release if the expected URL count doesn't match

## Test Plan

- [x] Confirm no bare backtick `docs/github-setup.md` references remain in `plugins/token-effort/skills/init-plus/SKILL.md`
- [x] Confirm all 5 versioned URLs in `SKILL.md` point to `blob/v0.6.0/docs/github-setup.md`
- [x] Simulate a release locally: run `sed -i "s|/blob/v[0-9]*\.[0-9]*\.[0-9]*/docs/github-setup|/blob/v0.7.0/docs/github-setup|g" plugins/token-effort/skills/init-plus/SKILL.md` and confirm 5 occurrences update
- [x] Confirm `release.yml` `git add` includes `plugins/token-effort/skills/init-plus/SKILL.md`

Closes #78