### PR TITLE
feat(configuring-dependabot): pre-commit detection + append-only merge (#77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Skills become `/token-effort:triaging-gh-issues`, `/token-effort:computing-branc
 | [init-plus](plugins/token-effort/skills/init-plus/SKILL.md) | Interactive repository setup with CLAUDE.md and workflows |
 | [move-issue-status](plugins/token-effort/skills/move-issue-status/SKILL.md) | Move issues between project board statuses |
 | [planning-gh-issue](plugins/token-effort/skills/planning-gh-issue/SKILL.md) | Write implementation plans for approved GitHub issues |
-| [proposing-feature](plugins/token-effort/skills/propose-feature/SKILL.md) | File new feature requests through guided interview |
+| [propose-feature](plugins/token-effort/skills/propose-feature/SKILL.md) | File new feature requests through guided interview |
 | [recording-decisions](plugins/token-effort/skills/recording-decisions/SKILL.md) | Record Architecture Decision Records (ADRs) in docs/decisions |
-| [reporting-bug](plugins/token-effort/skills/report-bug/SKILL.md) | File new bug reports through guided interview |
+| [report-bug](plugins/token-effort/skills/report-bug/SKILL.md) | File new bug reports through guided interview |
 | [reviewing-code-systematically](plugins/token-effort/skills/reviewing-code-systematically/SKILL.md) | Perform comprehensive code reviews on branches or main |
 | [triaging-gh-issues](plugins/token-effort/skills/triaging-gh-issues/SKILL.md) | Triage open issues: classify, label, and optionally advance project board status |
 

--- a/docs/decisions/2026-04-configuring-dependabot-append-only-merge.md
+++ b/docs/decisions/2026-04-configuring-dependabot-append-only-merge.md
@@ -1,0 +1,17 @@
+# 2026-04-configuring-dependabot-append-only-merge
+
+> **Status:** Active
+> **Issue:** [#77 — Add pre-commit ecosystem detection to `/init-plus` Dependabot config generation](https://github.com/HeadlessTarry/Token-Effort/issues/77)
+> **Date:** 2026-04-19
+
+## Context
+
+The `/configuring-dependabot` skill scans a repository for package ecosystem indicators and writes `.github/dependabot.yml`. Two gaps were identified: `.pre-commit-config.yaml` was not detected as an ecosystem indicator, and when a `dependabot.yml` already existed the skill prompted for whole-file overwrite — silently destroying any manually maintained configuration including any existing `pre-commit` entries.
+
+## Decision
+
+Added `.pre-commit-config.yaml` → `pre-commit` ecosystem detection to Phase 1. Replaced the whole-file overwrite prompt with an append-only merge in Phase 2: read the existing file, classify each detected ecosystem as New/Identical/Conflicting, append only New ecosystems without prompting, ask per-conflicting-ecosystem whether to overwrite or retain, and skip Identical entries silently. Phase 3 write logic was updated to handle the three-bucket outcome with surgical in-place replacement for Overwrite decisions.
+
+## Consequences
+
+Skills that call `configuring-dependabot` will no longer destructively overwrite existing `dependabot.yml` files; existing manual configurations are preserved. The append-only path increases Phase 2/3 complexity but eliminates the most destructive user-facing footgun. The per-ecosystem conflict prompt is more precise than a whole-file prompt but requires the user to make more decisions when multiple conflicts exist.

--- a/docs/training-guide.md
+++ b/docs/training-guide.md
@@ -13,7 +13,7 @@ Run training after:
 - Adding new eval cases that expose a gap in the current definition
 - Noticing consistent failure modes in real use
 
-If you edit a skill or agent file while Claude Code is active, the `suggest-training` PostToolUse hook (`plugins/token-effort/hooks/suggest-training.py`) will automatically prompt you to run training for the definition you just changed. You can accept or decline.
+If you edit a skill or agent file while Claude Code is active, the `suggest-training` PostToolUse hook (`.claude/hooks/suggest-training.py`) will automatically prompt you to run training for the definition you just changed. You can accept or decline.
 
 ## Invoking Training
 

--- a/plugins/token-effort/skills/configuring-dependabot/SKILL.md
+++ b/plugins/token-effort/skills/configuring-dependabot/SKILL.md
@@ -82,7 +82,12 @@ Check for **both** `.github/dependabot.yml` and `.github/dependabot.yaml`.
 
 ### Phase 3 — Write `.github/dependabot.yml`
 
-Write the file with one entry per detected ecosystem. Always use `directory: /`.
+**When no existing file is present:** write the full file from scratch with one entry per detected ecosystem. Always use `directory: /`.
+
+**When an existing file is present (from the Phase 2 merge):**
+- **New** ecosystems: append their YAML block to the end of the `updates:` list
+- **Overwrite** decisions: replace the conflicting entry's block in-place (from its `  - package-ecosystem:` line to the line before the next `  - package-ecosystem:` entry, or the end of the `updates:` list)
+- **Identical** and **Retain** entries: leave the file untouched
 
 **Cooldown support:** Only include the `cooldown` block for ecosystems that support it. The following ecosystems do **NOT** support cooldown and must not have a `cooldown` block:
 
@@ -122,7 +127,18 @@ updates:
 
 After writing, report:
 
+**Fresh file (no prior file existed):**
 > "Written `.github/dependabot.yml` with entries for: [comma-separated list of ecosystems]."
+
+**Existing file updated:**
+> "Updated `.github/dependabot.yml`: added [ecosystems], updated [ecosystems], retained [ecosystems]."
+
+Report key:
+- **added** = new ecosystems appended
+- **updated** = conflicting ecosystems the user chose to overwrite
+- **retained** = conflicting ecosystems the user chose to keep as-is
+- Identical entries are silently skipped and do not appear in the report
+- Omit any category with zero items
 
 ## Common Mistakes
 

--- a/plugins/token-effort/skills/configuring-dependabot/SKILL.md
+++ b/plugins/token-effort/skills/configuring-dependabot/SKILL.md
@@ -153,7 +153,7 @@ Report key:
 
 ## Eval
 
-- [ ] Scanned all six ecosystem indicator patterns using Glob
+- [ ] Scanned all seven ecosystem indicator patterns using Glob
 - [ ] Deduplicated ecosystems (no duplicate entries for pip, bundler, etc.)
 - [ ] Reported "no ecosystems detected" and stopped (no file written) when none found
 - [ ] Checked for both `.github/dependabot.yml` and `.github/dependabot.yaml`

--- a/plugins/token-effort/skills/configuring-dependabot/SKILL.md
+++ b/plugins/token-effort/skills/configuring-dependabot/SKILL.md
@@ -61,11 +61,24 @@ Check for **both** `.github/dependabot.yml` and `.github/dependabot.yaml`.
 
   Ask: "Proceed? [yes/no]" — if the user says no, stop without writing.
 
-- If `.github/dependabot.yml` exists: warn the user:
+- If `.github/dependabot.yml` exists, apply an **append-only merge**:
 
-  > "`.github/dependabot.yml` already exists. Overwrite? [yes/no]"
+  1. **Read** the file and extract all `package-ecosystem:` values from the `updates:` list using text matching.
+  2. **Classify** each detected ecosystem into one of three buckets:
+     - **New** — not present in the existing file → will be appended in Phase 3
+     - **Identical** — present and matches the standard config (weekly schedule + correct cooldown presence/absence for this ecosystem) → skip silently
+     - **Conflicting** — present but differs from standard config (e.g. different schedule interval, unexpected cooldown block) → needs user decision
+  3. **Resolve conflicts** — for each conflicting ecosystem, ask:
 
-  Wait for user confirmation. If the user says no or skips, stop without writing.
+     > "`<ecosystem>` is already configured but differs from the standard settings. Overwrite with standard config, or retain your existing entry?"
+
+     Ask one ecosystem at a time. Collect all decisions before writing anything.
+
+  If all detected ecosystems are Identical (nothing new, nothing conflicting), report:
+
+  > "`.github/dependabot.yml` is already up to date. No changes made."
+
+  Then stop without writing.
 
 ### Phase 3 — Write `.github/dependabot.yml`
 

--- a/plugins/token-effort/skills/configuring-dependabot/SKILL.md
+++ b/plugins/token-effort/skills/configuring-dependabot/SKILL.md
@@ -146,7 +146,9 @@ Report key:
 - **Writing duplicate ecosystem entries** — if both `requirements.txt` and `pyproject.toml` exist, write only one `pip` entry. If both `Gemfile` and `*.gemspec` exist, write only one `bundler` entry.
 - **Ignoring `.github/dependabot.yaml`** — always check for the `.yaml` variant (wrong extension) in addition to `.yml`. Warn the user if it exists.
 - **Writing the file when no ecosystems are detected** — if the scan finds no indicators, output the "no ecosystems" message and stop without writing.
-- **Skipping the overwrite confirmation** — always warn and ask if `.github/dependabot.yml` (or `.yaml`) exists.
+- **Prompting for whole-file overwrite when `.github/dependabot.yml` exists** — use the append-only merge path instead. The whole-file overwrite prompt has been removed; only per-ecosystem conflict prompts are used.
+- **Skipping the conflict prompt when an ecosystem is present with different settings** — always ask the user per-conflicting-ecosystem. Never silently overwrite or silently skip a conflicting entry.
+- **Failing to detect `.pre-commit-config.yaml`** — this file maps to the `pre-commit` ecosystem. It must be checked in Phase 1 alongside all other indicator files.
 - **Using a non-root directory** — always use `directory: /` unless the user specifies otherwise.
 
 ## Eval
@@ -156,7 +158,12 @@ Report key:
 - [ ] Reported "no ecosystems detected" and stopped (no file written) when none found
 - [ ] Checked for both `.github/dependabot.yml` and `.github/dependabot.yaml`
 - [ ] Warned about `.github/dependabot.yaml` (wrong extension) and asked before proceeding
-- [ ] Warned about existing `.github/dependabot.yml` and asked before overwriting
+- [ ] When `.github/dependabot.yml` exists: read file and classified each detected ecosystem as New / Identical / Conflicting before writing
+- [ ] Detected `pre-commit` ecosystem when `.pre-commit-config.yaml` is present; no cooldown block written for `pre-commit`
+- [ ] Appended only New ecosystems; left Identical entries untouched without any overwrite prompt
+- [ ] Asked user per-conflicting-ecosystem (not a whole-file overwrite prompt)
+- [ ] Completion report distinguishes added / updated / retained; omits zero-item categories
+- [ ] Reported "already up to date" when all detected ecosystems were Identical
 - [ ] Wrote one entry per detected ecosystem with `schedule.interval: weekly`
 - [ ] Included cooldown block only for ecosystems that support it (not github-actions)
 - [ ] Used `directory: /` for all ecosystems

--- a/plugins/token-effort/skills/configuring-dependabot/SKILL.md
+++ b/plugins/token-effort/skills/configuring-dependabot/SKILL.md
@@ -41,6 +41,7 @@ Use the Glob tool to check for each of the following patterns from the repo root
 | `go.mod` | `gomod` |
 | `Cargo.toml` | `cargo` |
 | `.github/workflows/*.yml` | `github-actions` (include whenever any workflow file exists) |
+| `.pre-commit-config.yaml` | `pre-commit` |
 
 Collect all **unique** matching ecosystems into an ordered list (preserve detection order above).
 

--- a/training/skills/configuring-dependabot/all-ecosystems-present-identical.md
+++ b/training/skills/configuring-dependabot/all-ecosystems-present-identical.md
@@ -1,0 +1,19 @@
+## Scenario
+A repository has package.json and .github/workflows/ci.yml. An existing .github/dependabot.yml
+already contains both npm (with standard weekly schedule and full cooldown block) and
+github-actions (with standard weekly schedule, no cooldown). No additional ecosystems are
+detected.
+
+## Expected Behavior
+The skill detects npm and github-actions. Phase 2 reads the existing file and classifies both
+as Identical — they already match the standard config. No file writes occur. The skill reports
+that no changes were needed.
+
+## Pass Criteria
+- [ ] Detected npm and github-actions ecosystems
+- [ ] Read the existing .github/dependabot.yml and extracted package-ecosystem values
+- [ ] Classified npm as Identical (weekly schedule + correct cooldown block)
+- [ ] Classified github-actions as Identical (weekly schedule, no cooldown block)
+- [ ] Did NOT write or modify the file
+- [ ] Did NOT prompt for overwrite confirmation
+- [ ] Reported that the file is already up to date (no "added" or "updated" in report)

--- a/training/skills/configuring-dependabot/append-new-ecosystem.md
+++ b/training/skills/configuring-dependabot/append-new-ecosystem.md
@@ -1,0 +1,20 @@
+## Scenario
+A repository has .github/workflows/ci.yml and package.json. An existing
+.github/dependabot.yml is present containing only a github-actions entry with the standard
+weekly schedule (no cooldown, as github-actions is cooldown-exempt).
+
+## Expected Behavior
+The skill detects github-actions and npm. Phase 2 reads the existing file and finds
+github-actions is already present with identical standard config. npm is new. The skill
+appends an npm entry without prompting for whole-file overwrite confirmation.
+
+## Pass Criteria
+- [ ] Detected github-actions and npm ecosystems
+- [ ] Read the existing .github/dependabot.yml and extracted package-ecosystem values
+- [ ] Classified github-actions as Identical (skip silently)
+- [ ] Classified npm as New (append)
+- [ ] Did NOT prompt for whole-file overwrite confirmation
+- [ ] Appended npm entry with schedule.interval: weekly and full cooldown block
+- [ ] Left the existing github-actions entry untouched
+- [ ] Completion report includes "added: npm"
+- [ ] Completion report does NOT mention github-actions (silently skipped)

--- a/training/skills/configuring-dependabot/conflict-user-overwrites.md
+++ b/training/skills/configuring-dependabot/conflict-user-overwrites.md
@@ -1,0 +1,19 @@
+## Scenario
+A repository has package.json. An existing .github/dependabot.yml contains an npm entry with
+schedule.interval: monthly (differs from the standard weekly). The user chooses to overwrite
+when prompted.
+
+## Expected Behavior
+The skill detects npm. Phase 2 reads the existing file, finds npm is present but with a monthly
+schedule (conflicting). The skill asks the user whether to overwrite or retain. When the user
+chooses overwrite, the npm entry is replaced in-place with the standard weekly schedule and
+cooldown block.
+
+## Pass Criteria
+- [ ] Detected npm ecosystem from package.json
+- [ ] Read the existing .github/dependabot.yml and extracted package-ecosystem values
+- [ ] Classified npm as Conflicting (monthly schedule differs from standard weekly)
+- [ ] Asked user: "npm is already configured but differs from the standard settings. Overwrite with standard config, or retain your existing entry?"
+- [ ] Did NOT prompt for whole-file overwrite
+- [ ] After user chose overwrite: replaced the npm entry in-place with schedule.interval: weekly and full cooldown block
+- [ ] Completion report includes "updated: npm"

--- a/training/skills/configuring-dependabot/conflict-user-retains.md
+++ b/training/skills/configuring-dependabot/conflict-user-retains.md
@@ -1,0 +1,18 @@
+## Scenario
+A repository has package.json. An existing .github/dependabot.yml contains an npm entry with
+schedule.interval: monthly (differs from the standard weekly). The user chooses to retain when
+prompted.
+
+## Expected Behavior
+The skill detects npm. Phase 2 reads the existing file, finds npm is conflicting. The skill
+asks the user whether to overwrite or retain. When the user chooses retain, the file is left
+unchanged.
+
+## Pass Criteria
+- [ ] Detected npm ecosystem from package.json
+- [ ] Read the existing .github/dependabot.yml and extracted package-ecosystem values
+- [ ] Classified npm as Conflicting (monthly schedule differs from standard weekly)
+- [ ] Asked user whether to overwrite or retain
+- [ ] After user chose retain: did NOT modify the npm entry
+- [ ] The file's npm entry still has schedule.interval: monthly after completion
+- [ ] Completion report includes "retained: npm"

--- a/training/skills/configuring-dependabot/existing-file-overwrite-prompt.md
+++ b/training/skills/configuring-dependabot/existing-file-overwrite-prompt.md
@@ -1,13 +1,14 @@
 ## Scenario
-A repository has .github/workflows/ci.yml and .github/dependabot.yml already present.
+A repository has .github/workflows/ci.yml. An existing .github/dependabot.yml is present
+containing only a github-actions entry with the standard weekly schedule (no cooldown).
 
 ## Expected Behavior
-The skill detects github-actions, then checks for an existing dependabot.yml, warns the
-user it already exists, and asks for confirmation before overwriting. If the user says no,
-the skill stops without writing.
+The skill detects github-actions. Phase 2 reads the existing file, classifies github-actions
+as Identical, and stops cleanly without writing — no whole-file overwrite prompt is shown.
 
 ## Pass Criteria
-- [ ] Warned user that .github/dependabot.yml already exists
-- [ ] Asked "Overwrite? [yes/no]" before writing
-- [ ] Did NOT overwrite the file when user said no
-- [ ] Stopped cleanly without error when user declined
+- [ ] Detected github-actions ecosystem from .github/workflows/ci.yml
+- [ ] Read the existing .github/dependabot.yml and extracted package-ecosystem values
+- [ ] Classified github-actions as Identical (no whole-file overwrite prompt shown)
+- [ ] Did NOT write or modify the file
+- [ ] Reported that the file is already up to date

--- a/training/skills/configuring-dependabot/overwrite-confirmed-yes.md
+++ b/training/skills/configuring-dependabot/overwrite-confirmed-yes.md
@@ -1,16 +1,20 @@
 ## Scenario
-A repository has Cargo.toml and an existing .github/dependabot.yml. The user confirms
-"yes" when asked about overwriting.
+A repository has Cargo.toml. An existing .github/dependabot.yml contains a cargo entry with
+schedule.interval: monthly (differs from the standard weekly). The user confirms "overwrite"
+when prompted.
 
 ## Expected Behavior
-The skill warns about the existing file, receives confirmation, and writes the new
-.github/dependabot.yml with a cargo entry including cooldown (cargo supports cooldown).
+The skill detects cargo. Phase 2 reads the existing file, classifies cargo as Conflicting
+(monthly schedule vs standard weekly). The skill asks per-ecosystem whether to overwrite or
+retain. The user says overwrite. The cargo entry is replaced in-place with the standard config.
 
 ## Pass Criteria
 - [ ] Detected cargo ecosystem from Cargo.toml
-- [ ] Warned user that .github/dependabot.yml already exists
-- [ ] Asked for confirmation before overwriting
-- [ ] Overwrote the file after user confirmed yes
-- [ ] Written file contains a cargo entry with schedule.interval: weekly
-- [ ] cargo entry includes full cooldown block
-- [ ] Reported cargo in completion message
+- [ ] Read the existing .github/dependabot.yml and extracted package-ecosystem values
+- [ ] Classified cargo as Conflicting (monthly schedule differs from standard weekly)
+- [ ] Asked user: "cargo is already configured but differs from the standard settings. Overwrite with standard config, or retain your existing entry?"
+- [ ] Did NOT prompt for whole-file overwrite
+- [ ] After user chose overwrite: replaced the cargo entry in-place
+- [ ] Written cargo entry has schedule.interval: weekly
+- [ ] Written cargo entry includes full cooldown block (cargo supports cooldown)
+- [ ] Completion report includes "updated: cargo"

--- a/training/skills/configuring-dependabot/pre-commit-detected.md
+++ b/training/skills/configuring-dependabot/pre-commit-detected.md
@@ -1,0 +1,16 @@
+## Scenario
+A repository contains only .pre-commit-config.yaml at the root. No other ecosystem indicators
+exist. No .github/dependabot.yml exists.
+
+## Expected Behavior
+The skill detects pre-commit, skips Phase 2 (no existing file), and writes
+.github/dependabot.yml with a single pre-commit entry. The pre-commit entry does not include a
+cooldown block because pre-commit is in the cooldown-exempt list.
+
+## Pass Criteria
+- [ ] Detected pre-commit ecosystem from .pre-commit-config.yaml
+- [ ] Wrote .github/dependabot.yml
+- [ ] Written file contains exactly one entry with package-ecosystem: pre-commit
+- [ ] Entry includes schedule.interval: weekly
+- [ ] Entry does NOT include a cooldown block
+- [ ] Reported pre-commit in completion message


### PR DESCRIPTION
## Summary

- Adds `.pre-commit-config.yaml` → `pre-commit` ecosystem detection to Phase 1
- Replaces the whole-file overwrite prompt with an append-only merge (New / Identical / Conflicting classification) that only prompts per-conflicting-ecosystem
- Adds 5 new eval cases, rewrites 2 existing ones; training score 1.0 (102/102)

## Changes

- `plugins/token-effort/skills/configuring-dependabot/SKILL.md` — Phase 1 table, Phase 2 merge logic, Phase 3 conditional write, Common Mistakes, Eval checklist
- `training/skills/configuring-dependabot/` — 5 new eval cases + 2 rewritten
- `docs/decisions/2026-04-configuring-dependabot-append-only-merge.md` — ADR
- `README.md` — fix wrong skill names (`proposing-feature` → `propose-feature`, `reporting-bug` → `report-bug`)
- `docs/training-guide.md` — fix wrong path for `suggest-training.py` hook

## Test Plan

- [x] Run `/token-effort:configuring-dependabot` on a repo with `.pre-commit-config.yaml` — verify `pre-commit` entry written with no cooldown block
- [x] Run on a repo with an existing `dependabot.yml` containing an identical entry — verify no prompt, no write, "already up to date" reported
- [x] Run on a repo where an existing ecosystem has a different schedule — verify per-ecosystem conflict prompt appears
- [x] Run `/run-training configuring-dependabot` — verify 15 evals pass

Closes #77

🤖 Generated with [Claude Code](https://claude.ai/claude-code)