### PR TITLE
Invert the choice of execution skill when building a plan - subagent driven development is the new default

### DIFF
--- a/plugins/token-effort/skills/building-gh-issue/SKILL.md
+++ b/plugins/token-effort/skills/building-gh-issue/SKILL.md
@@ -75,8 +75,8 @@ Assess the plan extracted in Phase 1. Choose the execution skill:
 
 | Skill | When to use |
 |-------|-------------|
-| `superpowers:executing-plans` | **Default.** Use for most plans. |
-| `superpowers:subagent-driven-development` | Use **only** when ALL THREE of the following apply: (1) the plan has many independent tasks with no sequential dependencies between them, (2) changes span 5 or more separate subsystems/modules, and (3) the plan is explicitly scoped as large or complex. |
+| `superpowers:subagent-driven-development` | **Default.** Use for most plans. |
+| `superpowers:executing-plans` | Use **only** when the implementation plan (1) has a single step and (2) touches only 1-2 files. |
 
 Invoke the chosen skill with the plan content injected as context, and the following **mandatory suppression instruction** included verbatim in the prompt:
 
@@ -148,7 +148,7 @@ This step creates the pull request. It runs exactly once, here, at the end of th
 - **Proceeding without a plan comment** — if `<!-- token-effort:planning-gh-issue -->` is not found in the issue, abort immediately with the message to run `/token-effort:planning-gh-issue #N` first. Do not proceed to execution without an approved plan.
 - **Omitting the suppression instruction from the Phase 3 prompt** — the verbatim instruction `"Do not invoke finishing-a-development-branch — this will be handled by the calling skill after all review steps complete."` must be included in the execution skill invocation. Paraphrasing it or omitting it is incorrect.
 - **Calling `finishing-a-development-branch` inside the Phase 3 execution skill** — the PR creation step belongs at Phase 9 and only there. The suppression instruction in Phase 3 enforces this; do not override it.
-- **Choosing `subagent-driven-development` for moderate-scope plans** — the default is `executing-plans`. Only switch to `subagent-driven-development` when all three conditions (independent tasks, 5+ subsystems, explicitly large/complex scope) are met simultaneously.
+- **Choosing `executing-plans` for non-trivial scope plans** — the default is `subagent-driven-development`. Only switch to `executing-plans` when all conditions (single-step plan, no more than 2 files touched) are met simultaneously.
 - **Silently skipping Phase 4** — Phase 4 is optional but must log a named warning when skipped. Do not silently continue without the warning.
 - **Continuing past Phase 8 when `recording-decisions` is unavailable** — Phase 8 is a hard block. If the skill is not installed, stop with the error message. Do not warn and continue.
 - **Passing the full raw comment body to the execution skill** — strip both the `<!-- brainstorming-gh-issue:spec -->` and `<!-- token-effort:planning-gh-issue -->` marker lines before using their content. Do not include markers in the context.
@@ -167,7 +167,7 @@ This step creates the pull request. It runs exactly once, here, at the end of th
 - [ ] Called `token-effort:move-issue-status <N> "Building"` in Phase 2
 - [ ] Phase 2 failure logged as a warning and did not block the build
 - [ ] Assessed plan complexity before choosing execution skill
-- [ ] Used `executing-plans` by default; `subagent-driven-development` only when all three conditions apply
+- [ ] Used `subagent-driven-development` by default; `executing-plans` only when all conditions apply
 - [ ] Plan content (marker stripped) passed to execution skill as context
 - [ ] Suppression instruction present verbatim in the execution skill invocation prompt
 - [ ] Attempted `/verify` and skipped with named warning if absent

--- a/plugins/token-effort/skills/planning-gh-issue/SKILL.md
+++ b/plugins/token-effort/skills/planning-gh-issue/SKILL.md
@@ -124,7 +124,7 @@ If re-entry mode and a prior plan was found, append:
 - Treat the design spec as the approved input brief. Do not revisit or re-question decisions already captured in the spec.
 - Run the full interactive planning loop through user approval.
 - Do not make any git commits — the plan content will be posted to GitHub as a comment after approval.
-- After the user approves the plan, do **not** call `superpowers:executing-plans` or any execution skill. Proceed to Phase 4 of this skill instead.
+- After the user approves the plan, do **not** call `superpowers:subagent-driven-development`, `superpowers:executing-plans` or any other build/execution skill. Proceed to Phase 4 of this skill instead.
 
 Wait for the user to approve the plan. Do not proceed to Phase 4 until approval is given.
 
@@ -194,7 +194,7 @@ After Phase 4 completes, report:
 - **Posting the plan before the user approves it** — Phase 4 must not run until the user has explicitly approved the plan within the `superpowers:writing-plans` session. Do not call `gh issue comment` or `gh issue edit` during Phase 3.
 - **Not reading the plan file before posting** — always locate and read the file that writing-plans wrote with `ls -t ~/.claude/plans/*.md | head -1`. Do not reconstruct the plan content from memory.
 - **Forgetting the HTML comment marker** — the plan comment must begin with `<!-- token-effort:planning-gh-issue -->` on its own line so future re-entry runs can locate it reliably.
-- **Invoking execution skills after plan approval** — the Phase 3 handoff instructs writing-plans to stop after the user approves the plan. Do not invoke `superpowers:executing-plans` or any build skill; proceed to Phase 4 instead.
+- **Invoking execution skills after plan approval** — the Phase 3 handoff instructs writing-plans to stop after the user approves the plan. Do not invoke `superpowers:subagent-driven-development`, `superpowers:executing-plans` or any build skill; proceed to Phase 4 instead.
 - **Creating `pending-review` without checking first** — always run `gh label list` before `gh label create` to avoid an error if the label already exists.
 - **Re-asking questions answered in the spec** — the design spec is the approved input brief. Instruct writing-plans not to revisit decisions already captured there.
 - **Using shell expansion syntax** — never use `${VARIABLE}`, `${VARIABLE:-}`, or any `${...}` form. Claude Code's sandbox blocks these. Use `printenv VARIABLE` to read environment variables.

--- a/training/skills/building-gh-issue/default-to-subagent-driven-development.md
+++ b/training/skills/building-gh-issue/default-to-subagent-driven-development.md
@@ -1,0 +1,16 @@
+## Scenario
+
+The user runs `/token-effort:building-gh-issue 55`. Valid spec and plan comments exist. The plan covers 2 sequential steps — moderate scope, not explicitly designated large or complex.
+
+## Expected Behaviour
+
+- Phase 3 assesses plan complexity before choosing an execution skill.
+- The plan is determined to be of non-trivial scope (either more than one step and/or >2 files modified)
+- `superpowers:subagent-driven-development` is chosen for Phase 3.
+- `superpowers:executing-plans` is NOT invoked.
+
+## Pass Criteria
+
+- [ ] Plan complexity is assessed before Phase 3 execution begins.
+- [ ] `superpowers:subagent-driven-development` is invoked for Phase 3.
+- [ ] `superpowers:executing-plans` is NOT invoked.

--- a/training/skills/building-gh-issue/suppresses-finishing-branch.md
+++ b/training/skills/building-gh-issue/suppresses-finishing-branch.md
@@ -1,16 +1,16 @@
 ## Scenario
 
-The user runs `/token-effort:building-gh-issue 31`. Valid spec and plan comments exist on the issue. The plan is moderate in scope — it covers one subsystem with a few sequential steps — and the skill selects `superpowers:executing-plans` for Phase 3.
+The user runs `/token-effort:building-gh-issue 31`. Valid spec and plan comments exist on the issue. The plan is moderate in scope — it covers one subsystem with a few sequential steps — and the skill selects `superpowers:subagent-driven-development` for Phase 3.
 
 ## Expected Behaviour
 
-- Phase 3 invokes `superpowers:executing-plans` with the verbatim suppression instruction embedded in the prompt: "Do not invoke `finishing-a-development-branch` — this will be handled by the calling skill after all review steps complete."
-- `executing-plans` respects the suppression and does NOT call `superpowers:finishing-a-development-branch` internally.
+- Phase 3 invokes `superpowers:subagent-driven-development` with the verbatim suppression instruction embedded in the prompt: "Do not invoke `finishing-a-development-branch` — this will be handled by the calling skill after all review steps complete."
+- `subagent-driven-development` respects the suppression and does NOT call `superpowers:finishing-a-development-branch` internally.
 - `superpowers:finishing-a-development-branch` is called exactly once, at Phase 9, after all review steps complete.
 
 ## Pass Criteria
 
-- [ ] `superpowers:executing-plans` is chosen for Phase 3 (not `superpowers:subagent-driven-development`).
-- [ ] The invocation prompt for `superpowers:executing-plans` contains the exact text: "Do not invoke `finishing-a-development-branch` — this will be handled by the calling skill after all review steps complete."
+- [ ] `superpowers:subagent-driven-development` is chosen for Phase 3 (not `superpowers:executing-plans`).
+- [ ] The invocation prompt for `superpowers:subagent-driven-development` contains the exact text: "Do not invoke `finishing-a-development-branch` — this will be handled by the calling skill after all review steps complete."
 - [ ] `superpowers:finishing-a-development-branch` is NOT called during or inside Phase 3.
 - [ ] `superpowers:finishing-a-development-branch` is called exactly once, at Phase 9.

--- a/training/skills/building-gh-issue/trivial-change-inline-execution.md
+++ b/training/skills/building-gh-issue/trivial-change-inline-execution.md
@@ -1,17 +1,16 @@
 ## Scenario
 
-The user runs `/token-effort:building-gh-issue 55`. Valid spec and plan comments exist. The plan covers 2 subsystems with mostly sequential steps — moderate scope, not explicitly designated large or complex.
+The user runs `/token-effort:building-gh-issue 42`. Valid spec and plan comments exist. The plan is composed of a single step - modifying 2 files only.
 
 ## Expected Behaviour
 
 - Phase 3 assesses plan complexity before choosing an execution skill.
-- The plan is determined to be moderate scope (fewer than 5 subsystems, no large-scope designation).
+- The plan is determined to be of trivial scope (a single step, with only <=2 files modified).
 - `superpowers:executing-plans` is chosen for Phase 3.
 - `superpowers:subagent-driven-development` is NOT invoked.
 
 ## Pass Criteria
 
 - [ ] Plan complexity is assessed before Phase 3 execution begins.
-- [ ] Plan is determined to be moderate scope (fewer than 5 subsystems, no explicit large-scope designation).
 - [ ] `superpowers:executing-plans` is invoked for Phase 3.
 - [ ] `superpowers:subagent-driven-development` is NOT invoked.


### PR DESCRIPTION
`/building-gh-issue` skill now uses `/subagent-driven-development` skill by default.

Fixes #89