### PR TITLE
fix: Windows compatibility for move-issue-status (#91)

### DIFF
--- a/plugins/token-effort/skills/move-issue-status/SKILL.md
+++ b/plugins/token-effort/skills/move-issue-status/SKILL.md
@@ -36,13 +36,9 @@ Python 3 and `gh` CLI must be available. `CLAUDE_PLUGIN_ROOT` must be set (injec
 
 ### Phase 1 — Locate the script
 
-Run:
+The `Base directory for this skill:` header injected at the top of this skill invocation gives the directory containing `move_issue_status.py`. No bash command is needed.
 
-```bash
-printenv CLAUDE_PLUGIN_ROOT
-```
-
-The Python script path is: `<output>/skills/move-issue-status/move_issue_status.py`
+The Python script path is: `<base-directory>/move_issue_status.py`
 
 ### Phase 2 — Run the script
 
@@ -72,8 +68,8 @@ Use the `status` field from the JSON to determine output:
 
 ## ⚠️ Common Mistakes
 
-- **Not reading `CLAUDE_PLUGIN_ROOT` via `printenv`** — never use `${CLAUDE_PLUGIN_ROOT}` (shell expansion is blocked). Always run `printenv CLAUDE_PLUGIN_ROOT` first.
-- **Reconstructing the script path from memory** — always derive the script path from the `printenv CLAUDE_PLUGIN_ROOT` output at runtime.
+- **Not reading the script path from skill metadata** — never use `${CLAUDE_PLUGIN_ROOT}` (shell expansion is blocked) or `printenv CLAUDE_PLUGIN_ROOT` (unreliable on Windows). Always derive the script path from the `Base directory for this skill:` header injected at the top of this skill invocation.
+- **Reconstructing the script path from memory** — always derive the script path from the `Base directory for this skill:` header at runtime, not from a remembered or hard-coded path.
 - **Printing output for skipped results** — `status == "skipped"` means stop silently. No output.
 - **Treating `status == "error"` as fatal** — report the `message` and stop, but do not raise an exception or block callers.
 - **Passing the `#` prefix to the script** — strip `#` before constructing the command.
@@ -81,8 +77,8 @@ Use the `status` field from the JSON to determine output:
 
 ## Eval
 
-- [ ] Called `printenv CLAUDE_PLUGIN_ROOT` to locate the script
-- [ ] Constructed script path as `<CLAUDE_PLUGIN_ROOT>/skills/move-issue-status/move_issue_status.py`
+- [ ] Read script path from the `Base directory for this skill:` header in the skill invocation metadata
+- [ ] Constructed script path as `<base-directory>/move_issue_status.py`
 - [ ] Stripped leading `#` from issue number before invoking the script
 - [ ] Ran `python "<script-path>" <issue-number> [<status>]` via Bash
 - [ ] Parsed stdout as JSON

--- a/plugins/token-effort/skills/move-issue-status/move_issue_status.py
+++ b/plugins/token-effort/skills/move-issue-status/move_issue_status.py
@@ -18,7 +18,7 @@ def resolve_repo() -> tuple[str, str]:
 
     result = subprocess.run(
         ["git", "remote", "get-url", "origin"],
-        capture_output=True, text=True,
+        capture_output=True, text=True, encoding="utf-8",
     )
     url = result.stdout.strip()
     if url.startswith("https://"):
@@ -36,7 +36,7 @@ def resolve_repo() -> tuple[str, str]:
 def find_project_item(owner: str, issue_number: int) -> list[dict]:
     result = subprocess.run(
         ["gh", "project", "list", "--owner", owner, "--format", "json", "--limit", "100"],  # practical cap; raise if >100 projects
-        capture_output=True, text=True,
+        capture_output=True, text=True, encoding="utf-8",
     )
     data = json.loads(result.stdout)
 
@@ -46,7 +46,7 @@ def find_project_item(owner: str, issue_number: int) -> list[dict]:
         items_result = subprocess.run(
             ["gh", "project", "item-list", str(pnum),
              "--owner", owner, "--format", "json", "--limit", "1000"],  # boards with >1000 items may miss matches
-            capture_output=True, text=True,
+            capture_output=True, text=True, encoding="utf-8",
         )
         items_data = json.loads(items_result.stdout)
         for item in items_data.get("items", []):
@@ -65,7 +65,7 @@ def get_status_field(owner: str, project_number: int) -> dict | None:
     result = subprocess.run(
         ["gh", "project", "field-list", str(project_number),
          "--owner", owner, "--format", "json"],
-        capture_output=True, text=True,
+        capture_output=True, text=True, encoding="utf-8",
     )
     data = json.loads(result.stdout)
     for field in data.get("fields", []):
@@ -122,7 +122,7 @@ def run(issue_number: int, target_status: str | None) -> dict:
          "--id", match["item_id"],
          "--field-id", field["field_id"],
          "--single-select-option-id", target_option["id"]],
-        capture_output=True, text=True,
+        capture_output=True, text=True, encoding="utf-8",
     )
     return {"status": "moved", "issue": issue_number, "to": target_option["name"], "project": match["project_name"]}
 

--- a/training/skills/move-issue-status/locates-script-via-printenv.md
+++ b/training/skills/move-issue-status/locates-script-via-printenv.md
@@ -4,10 +4,12 @@ The user runs `/token-effort:move-issue-status 42`. The skill must locate the Py
 
 ## Expected Behavior
 
-The skill runs `printenv CLAUDE_PLUGIN_ROOT` to discover the plugin root, then constructs the script path as `<output>/skills/move-issue-status/move_issue_status.py`. It does not hard-code any path, use `${CLAUDE_PLUGIN_ROOT}`, or assume the script location from memory.
+The skill reads the `Base directory for this skill:` header injected at the top of the skill invocation to discover the script directory, then constructs the script path as `<base-directory>/move_issue_status.py`. It does not use `printenv CLAUDE_PLUGIN_ROOT`, hard-code any path, use `${CLAUDE_PLUGIN_ROOT}`, or assume the script location from memory.
 
 ## Pass Criteria
 
-- [ ] Ran `printenv CLAUDE_PLUGIN_ROOT` as a Bash command
-- [ ] Constructed the script path using the output of `printenv`, not a hard-coded or assumed path
+- [ ] Derived the script path from the `Base directory for this skill:` header in the skill invocation metadata
+- [ ] Constructed the script path as `<base-directory>/move_issue_status.py`
+- [ ] Did NOT use `printenv CLAUDE_PLUGIN_ROOT`
 - [ ] Did NOT use `${CLAUDE_PLUGIN_ROOT}` or any `${...}` shell expansion
+- [ ] Did NOT hard-code or assume the script path from memory


### PR DESCRIPTION
## Summary

- Adds `encoding="utf-8"` to all 5 `subprocess.run()` calls in `move_issue_status.py`, preventing `UnicodeDecodeError` (cp1252) when `gh` CLI output contains non-ASCII characters on Windows
- Replaces `printenv CLAUDE_PLUGIN_ROOT` with the `Base directory for this skill:` metadata header injected by Claude Code, which is reliably available on all platforms
- Updates the training eval to expect the metadata-based path lookup

## Test plan

- [x] Run `python -m pytest tests/skills/test_move_issue_status.py -v` — all 20 tests pass
- [x] On Windows, invoke `/token-effort:move-issue-status <N> "<status>"` against an issue on the project board — confirm `{"status": "moved", ...}` with no UnicodeDecodeError
- [ ] Cross-platform check: run the same flow on macOS/Linux to confirm no regression. ❌ **Unable to do this - only a Windows device available**

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)