### PR TITLE
feat: add mandatory confirmation gate to recording-decisions skill (#72)

### DIFF
--- a/docs/decisions/2026-04-recording-decisions-confirmation-gate.md
+++ b/docs/decisions/2026-04-recording-decisions-confirmation-gate.md
@@ -1,0 +1,28 @@
+# 2026-04-recording-decisions-confirmation-gate
+
+> **Status:** Active
+> **Issue:** [#72 — recording-decisions skill skips user confirmation when invoked from building-gh-issue](https://github.com/HeadlessTarry/Token-Effort/issues/72)
+> **Date:** 2026-04-26
+
+## Context
+
+The `token-effort:recording-decisions` skill is designed to present each ADR field
+(Slug, Context, Decision, Consequences) to the user for review before committing.
+When invoked from `token-effort:building-gh-issue` Phase 8, rich spec context
+pre-populates all fields — and the model was observed skipping the confirmation
+loop, committing the ADR directly without user review.
+
+## Decision
+
+Add mandatory per-field `AskUserQuestion` confirmations for Slug, Context, Decision,
+and Consequences. Insert a new Phase 4 final approval gate: after Phase 3, assemble
+the complete ADR in memory, present it via `AskUserQuestion`, and require an explicit
+`yes` before any file write or git commit. Any non-yes response is treated as a
+change request and loops back.
+
+## Consequences
+
+Users can no longer skip the confirmation loop regardless of how much spec context
+is pre-populated. The approval gate adds one additional interaction round per build
+but ensures the ADR reflects user intent. Only explicit `yes` (case-insensitive)
+exits the loop — ambiguous affirmatives (e.g. `ok`, `looks good`) do not count.

--- a/plugins/token-effort/skills/recording-decisions/SKILL.md
+++ b/plugins/token-effort/skills/recording-decisions/SKILL.md
@@ -159,17 +159,56 @@ If not found, warn and re-prompt — do not silently skip:
 
 6. **If none superseded:** Status = `Active`, no existing files modified.
 
-#### Phase 4 — Create `docs/decisions/` if needed
+#### Phase 4 — Final approval gate
+
+Assemble the complete ADR text in memory using all confirmed fields from Phase 2 and the
+supersession outcome from Phase 3. Do **not** write any file yet.
+
+Present the full rendered ADR to the user via `AskUserQuestion`:
+
+````
+Here is the ADR that will be committed. Please review and reply `yes` to confirm, or describe any changes:
+
+---
+# YYYY-MM-<slug>
+
+> **Status:** Active  (or Supersedes ... if applicable)
+> **Issue:** [#N — Title](https://github.com/owner/repo/issues/N)
+> **Date:** YYYY-MM-DD
+
+## Context
+
+<confirmed context text>
+
+## Decision
+
+<confirmed decision text>
+
+## Consequences
+
+<confirmed consequences text>
+---
+````
+
+Wait for the user's response.
+
+- If the user replies `yes` (case-insensitive): proceed to Phase 5.
+- If the user requests changes: apply the requested changes, re-assemble the full ADR draft, and call
+  `AskUserQuestion` again with the revised draft. Repeat this loop until the user replies `yes`.
+
+**You MUST NOT write the ADR file, run `mkdir`, or call `git commit` until the user replies `yes`.**
+
+#### Phase 5 — Create `docs/decisions/` if needed
 
 ```bash
 mkdir -p docs/decisions
 ```
 
-#### Phase 5 — Write the ADR file
+#### Phase 6 — Write the ADR file
 
 Assemble the ADR from confirmed fields and write to `docs/decisions/YYYY-MM-<slug>.md`.
 
-#### Phase 6 — Commit
+#### Phase 7 — Commit
 
 ```bash
 git add docs/decisions/

--- a/plugins/token-effort/skills/recording-decisions/SKILL.md
+++ b/plugins/token-effort/skills/recording-decisions/SKILL.md
@@ -193,8 +193,9 @@ Here is the ADR that will be committed. Please review and reply `yes` to confirm
 Wait for the user's response.
 
 - If the user replies `yes` (case-insensitive): proceed to Phase 5.
-- If the user requests changes: apply the requested changes, re-assemble the full ADR draft, and call
-  `AskUserQuestion` again with the revised draft. Repeat this loop until the user replies `yes`.
+- Any response other than `yes` (case-insensitive) is treated as a change request. Apply the requested
+  changes, re-assemble the full ADR draft, and call `AskUserQuestion` again with the revised draft.
+  There is no iteration limit — repeat until the user replies `yes`.
 
 **You MUST NOT write the ADR file, run `mkdir`, or call `git commit` until the user replies `yes`.**
 
@@ -235,6 +236,9 @@ Report the committed file path to the user.
 - **Writing the file before final approval** — `AskUserQuestion` must be called with
   the full rendered ADR before `mkdir` or any file write. Commit and file write happen
   only after an explicit "yes".
+- **Treating ambiguous affirmatives as approval** — only `yes` (case-insensitive) exits
+  the Phase 4 approval loop. Responses like `looks good`, `ok`, or `fine` are change
+  requests, not approvals — apply them and re-present the draft.
 
 ### Eval
 

--- a/plugins/token-effort/skills/recording-decisions/SKILL.md
+++ b/plugins/token-effort/skills/recording-decisions/SKILL.md
@@ -229,12 +229,24 @@ Report the committed file path to the user.
   same commit as the new ADR. Never commit only the new file.
 - **Wrong location for supersession note** — the `> ⚠️ Superseded by ...` line goes
   immediately after the `# YYYY-MM-<slug>` heading, before the blockquote metadata.
+- **Skipping `AskUserQuestion` when context is rich** — even when all fields are
+  auto-populated from spec context, each field MUST be confirmed via `AskUserQuestion`.
+  Available context is not a substitute for explicit user confirmation.
+- **Writing the file before final approval** — `AskUserQuestion` must be called with
+  the full rendered ADR before `mkdir` or any file write. Commit and file write happen
+  only after an explicit "yes".
 
 ### Eval
 
 - [ ] Resolved owner/repo from `git remote get-url origin`
 - [ ] Used current year and zero-padded month for filename prefix
-- [ ] Presented each field for confirmation with auto-population when in `/token-effort:building-gh-issue` context
+- [ ] Called `AskUserQuestion` for Slug confirmation and waited for user response
+- [ ] Called `AskUserQuestion` for Context confirmation and waited for user response
+- [ ] Called `AskUserQuestion` for Decision confirmation and waited for user response
+- [ ] Called `AskUserQuestion` for Consequences confirmation and waited for user response
+- [ ] Assembled full ADR draft and called `AskUserQuestion` for final approval before writing the file
+- [ ] Did not write the ADR file or call `git commit` before receiving explicit user approval
+- [ ] Looped back to show a revised draft when the user requested changes at the final gate
 - [ ] Prompted all fields interactively when called standalone
 - [ ] Scanned `docs/decisions/` for potentially related ADRs and presented shortlist
 - [ ] Verified existence of any user-supplied filenames before accepting them

--- a/plugins/token-effort/skills/recording-decisions/SKILL.md
+++ b/plugins/token-effort/skills/recording-decisions/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: true
 
 ## ⛔ Dispatcher — Act on This Before Reading Further
 
-**Do not execute any step below.** Your only action is to spawn a Haiku subagent via the `Agent` tool with `model: haiku`. Embed all instructions under "Subagent Instructions" below verbatim as the subagent prompt, and include this instruction in the prompt: **"Use `AskUserQuestion` for any mid-task user interaction — slug confirmation, Context/Decision/Consequences field entry, and supersession selection."** `AskUserQuestion` is a standard Claude Code tool available to all subagents for synchronous mid-task user prompts. Report the subagent's result to the user without modification.
+**Do not execute any step below.** Your only action is to spawn a Haiku subagent via the `Agent` tool with `model: haiku`. Embed all instructions under "Subagent Instructions" below verbatim as the subagent prompt, and include this instruction in the prompt: **"Use `AskUserQuestion` for any mid-task user interaction — slug confirmation, Context/Decision/Consequences field entry, and supersession selection."** `AskUserQuestion` is a standard Claude Code tool available to all subagents for synchronous mid-task user prompts. **You MUST call `AskUserQuestion` for each of the following fields before proceeding: Slug, Context, Decision, Consequences. Do not infer acceptance from available context — each field requires an explicit user response.** **You MUST NOT write the ADR file or call `git commit` until the user has explicitly approved the full ADR via `AskUserQuestion`.** Report the subagent's result to the user without modification.
 
 ## 📋 Subagent Instructions — Pass Verbatim, Do Not Execute Directly
 

--- a/plugins/token-effort/skills/recording-decisions/SKILL.md
+++ b/plugins/token-effort/skills/recording-decisions/SKILL.md
@@ -85,30 +85,34 @@ spec context. When standalone, prompt for all fields.
 
 **1. Issue number and title**
 - `/token-effort:building-gh-issue` context: read issue number and title from context
-- Standalone: "What is the GitHub issue number for this decision? (e.g. 42)"
+- Standalone: call `AskUserQuestion` with the prompt `What is the GitHub issue number for this decision? (e.g. 42)`
 - Construct the full URL: `https://github.com/<owner>/<repo>/issues/<N>`
 
 **2. Slug**
 - `/token-effort:building-gh-issue` context: derive slug from the spec headline
 - Standalone with issue number: fetch title via `gh issue view <N> --json title -q .title`, then derive slug from that title
-- Standalone without issue: ask the user for a short description to derive the slug from
-- Show: `Suggested slug: \`<slug>\` — press Enter to accept or type a new one:`
-- Confirmed slug is used as the filename suffix
+- Standalone without issue: call `AskUserQuestion` with the prompt `Provide a short description to derive the slug from:`
+- Call `AskUserQuestion` with the prompt `Slug — accept or provide a replacement:` and the pre-populated value
+  (e.g. `recording-decisions-confirmation-gate`) shown in the message body. Wait for the user's response.
+- Confirmed slug is used as the filename suffix.
 
 **3. Context**
 - `/token-effort:building-gh-issue`: auto-populate from the spec's Context / problem statement section
-- Show the text and ask: `Context (from spec) — press Enter to accept or paste a replacement:`
-- Standalone: "Describe what problem prompted this decision:"
+- Call `AskUserQuestion` with the prompt `Context — accept or provide a replacement:` and the pre-populated text shown
+  in the message body. Wait for the user's response before continuing.
+- Standalone: call `AskUserQuestion` with the prompt `Describe what problem prompted this decision:`
 
 **4. Decision**
 - `/token-effort:building-gh-issue`: auto-populate from the spec's recommended approach section
-- Same confirmation pattern as Context
-- Standalone: "Describe what was decided and why:"
+- Call `AskUserQuestion` with the prompt `Decision — accept or provide a replacement:` and the pre-populated text shown
+  in the message body. Wait for the user's response before continuing.
+- Standalone: call `AskUserQuestion` with the prompt `Describe what was decided and why:`
 
 **5. Consequences**
 - `/token-effort:building-gh-issue`: auto-populate from the spec's trade-offs / limitations section
-- Same confirmation pattern as Context
-- Standalone: "Describe the trade-offs, known limitations, or anything that should inform future work:"
+- Call `AskUserQuestion` with the prompt `Consequences — accept or provide a replacement:` and the pre-populated text
+  shown in the message body. Wait for the user's response before continuing.
+- Standalone: call `AskUserQuestion` with the prompt `Describe the trade-offs, known limitations, or anything that should inform future work:`
 
 #### Phase 3 — Supersession check
 

--- a/training/skills/recording-decisions/approval-gate-revision-loop.md
+++ b/training/skills/recording-decisions/approval-gate-revision-loop.md
@@ -1,0 +1,21 @@
+## Scenario
+
+The user invokes `/token-effort:recording-decisions` standalone. After all fields are
+collected and Phase 3 completes, the skill presents the full rendered ADR. The user replies
+`change the Consequences section to mention migration cost`. The skill applies the change
+and presents the revised ADR again. The user replies `yes`.
+
+## Expected Behavior
+
+On the first `AskUserQuestion` at the approval gate, the user requests a change. The skill
+applies the change to the Consequences text, re-assembles the full ADR draft (all sections
+updated), and calls `AskUserQuestion` again with the revised ADR. It waits for `yes` before
+writing any file or committing.
+
+## Pass Criteria
+
+- [ ] First approval `AskUserQuestion` called with original ADR draft
+- [ ] After change request: Consequences text updated to mention migration cost
+- [ ] Second `AskUserQuestion` called with revised full ADR (all sections present, updated Consequences visible)
+- [ ] No file written or committed between first and second `AskUserQuestion`
+- [ ] After second `yes`: ADR file written and committed with revised Consequences

--- a/training/skills/recording-decisions/final-approval-gate.md
+++ b/training/skills/recording-decisions/final-approval-gate.md
@@ -1,0 +1,19 @@
+## Scenario
+
+The user invokes `/token-effort:recording-decisions` standalone. They fill in all fields
+(issue #55, slug `use-postgres-for-persistence`, short Context, Decision, and Consequences).
+After Phase 3 (no supersession), the skill presents the full rendered ADR and the user
+replies `yes`.
+
+## Expected Behavior
+
+The skill assembles the complete ADR in memory after Phase 3, calls `AskUserQuestion` with
+the full rendered ADR body, waits for the user's `yes`, then proceeds to create the directory,
+write the file, and commit. No file is written or committed before the `yes` reply.
+
+## Pass Criteria
+
+- [ ] `AskUserQuestion` called after Phase 3 with the full rendered ADR (heading, Status, Issue, Date, Context, Decision, Consequences) in the prompt body
+- [ ] No `mkdir` or file write occurred before the user replied `yes`
+- [ ] After `yes`: `docs/decisions/YYYY-MM-use-postgres-for-persistence.md` created
+- [ ] Committed with message `docs: record decision YYYY-MM-use-postgres-for-persistence (issue #55)`

--- a/training/skills/recording-decisions/happy-path-from-build.md
+++ b/training/skills/recording-decisions/happy-path-from-build.md
@@ -1,11 +1,12 @@
 ## Scenario
-The skill is invoked from Phase 9 of `/build` for issue #49. The spec context
+The skill is invoked from Phase 8 of `/token-effort:building-gh-issue` for issue #49. The spec context
 contains a "Context" section, a "Decision" section, and a "Consequences" section.
 The `docs/decisions/` directory already exists and is empty.
 
 ## Expected Behavior
 The skill auto-populates Context, Decision, and Consequences from the spec.
-It presents each field for confirmation, then writes and commits the ADR file.
+It calls `AskUserQuestion` to confirm each field, then presents the full rendered ADR
+for final approval before writing and committing the file.
 
 ## Pass Criteria
 - [ ] Called `AskUserQuestion` for Slug confirmation even though spec context was available

--- a/training/skills/recording-decisions/happy-path-from-build.md
+++ b/training/skills/recording-decisions/happy-path-from-build.md
@@ -8,7 +8,12 @@ The skill auto-populates Context, Decision, and Consequences from the spec.
 It presents each field for confirmation, then writes and commits the ADR file.
 
 ## Pass Criteria
-- [ ] Prompts for confirmation of each field (does not silently accept without showing)
+- [ ] Called `AskUserQuestion` for Slug confirmation even though spec context was available
+- [ ] Called `AskUserQuestion` for Context confirmation even though spec context was available
+- [ ] Called `AskUserQuestion` for Decision confirmation even though spec context was available
+- [ ] Called `AskUserQuestion` for Consequences confirmation even though spec context was available
+- [ ] Called `AskUserQuestion` with full rendered ADR before writing any file
+- [ ] No file written and no `git commit` run before user replied `yes`
 - [ ] Creates file at `docs/decisions/YYYY-MM-<slug>.md` using current year + zero-padded month
 - [ ] Status line is `Active` (no supersession)
 - [ ] Issue link in ADR points to `https://github.com/<owner>/<repo>/issues/49`

--- a/training/skills/recording-decisions/standalone-interactive.md
+++ b/training/skills/recording-decisions/standalone-interactive.md
@@ -14,3 +14,6 @@ auto-populated.
 - [ ] Presents the existing ADR as a potential supersession candidate
 - [ ] User can press Enter to skip supersession
 - [ ] ADR is written and committed after all fields confirmed
+- [ ] Called `AskUserQuestion` for each of Slug, Context, Decision, Consequences individually
+- [ ] Presented full rendered ADR via `AskUserQuestion` before writing the file
+- [ ] Did not write the ADR file or commit before user approval

--- a/training/skills/recording-decisions/supersession.md
+++ b/training/skills/recording-decisions/supersession.md
@@ -1,5 +1,5 @@
 ## Scenario
-The skill is invoked from `/build`. `docs/decisions/` contains two existing ADRs:
+The skill is invoked from `/token-effort:building-gh-issue`. `docs/decisions/` contains two existing ADRs:
 `2025-11-use-sqlite-for-storage.md` and `2025-08-auth-middleware-approach.md`.
 The user selects `2025-11-use-sqlite-for-storage.md` as superseded.
 


### PR DESCRIPTION
## Summary

- Adds mandatory `AskUserQuestion` calls for each ADR field (Slug, Context, Decision, Consequences) so the model cannot skip confirmation even when spec context is pre-populated
- Inserts a new Phase 4 final approval gate: full rendered ADR is shown to the user via `AskUserQuestion` before any file write or `git commit`; only explicit `yes` exits the loop
- Updates eval checklist, Common Mistakes, and training eval cases to cover the new behaviour; adds two new eval cases (`final-approval-gate`, `approval-gate-revision-loop`)

## Test Plan

- [x] Invoke `/token-effort:recording-decisions` standalone — verify four separate `AskUserQuestion` prompts appear (Slug, Context, Decision, Consequences), then a fifth with the full ADR draft before any file is written
- [x] Invoke from `/token-effort:building-gh-issue` Phase 8 with a spec in context — verify the same `AskUserQuestion` calls appear even though all fields are pre-populated
- [x] At the final approval gate, request a change — verify the skill loops, applies the change, and re-presents the full draft before committing
- [x] Reply `yes` at the final gate — verify the ADR is written to `docs/decisions/YYYY-MM-<slug>.md` and committed with the correct message format

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)