### PR TITLE
feat: add Phase 3 worktree isolation to building-gh-issue (#98)

### DIFF
--- a/docs/decisions/2026-04-worktree-isolation-for-building-gh-issue.md
+++ b/docs/decisions/2026-04-worktree-isolation-for-building-gh-issue.md
@@ -1,0 +1,17 @@
+# 🗂️ 2026-04-worktree-isolation-for-building-gh-issue
+
+> **Status:** Active
+> **Issue:** [#98 — building-gh-issue commits directly to main — no worktree or branch created](https://github.com/HeadlessTarry/Token-Effort/issues/98)
+> **Date:** 2026-04-26
+
+## 🔍 Context
+
+`building-gh-issue` dispatched execution skills that committed implementation work directly to whatever branch was currently checked out (typically `main`). There was no step to create a feature branch or Git worktree before execution began. The fix belongs in the skill itself — it must not rely on user-level CLAUDE.md configuration or on the execution skills calling `using-git-worktrees` themselves.
+
+## 🏛️ Decision
+
+Insert a new mandatory Phase 3 ("Create worktree") between Phase 2 (move issue to Building) and the execution phase. Phase 3 derives a branch name as `<N>-<slug>` — the issue number prepended to a lowercased, hyphenated, 50-character-truncated title slug — and invokes `superpowers:using-git-worktrees` with path `.claude/worktrees/<branch-name>`. The path and branch name are supplied explicitly so the skill's interactive directory-selection flow is bypassed. Phase 3 is fatal: failure stops the build immediately with a clear error. All subsequent phases were renumbered 4–10.
+
+## 🔮 Consequences
+
+All future `building-gh-issue` builds are isolated from `main` in a dedicated worktree. Branch naming is deterministic and derived from issue metadata at runtime. Phase 3 failure is a hard stop (unlike Phase 2, which is non-fatal and logs a warning). The `superpowers:using-git-worktrees` skill is now a required prerequisite and must be listed in the Prerequisites section of the skill.

--- a/plugins/token-effort/skills/building-gh-issue/SKILL.md
+++ b/plugins/token-effort/skills/building-gh-issue/SKILL.md
@@ -33,6 +33,7 @@ Strip any leading `#` from the issue number before use (e.g. `#42` → `42`).
 - The following `superpowers` skills must be installed:
   - `superpowers:executing-plans`
   - `superpowers:subagent-driven-development`
+  - `superpowers:using-git-worktrees`
   - `superpowers:finishing-a-development-branch`
 
 > **Important:** Do **not** use MCP tools (`mcp__plugin_github_github__*`) for any issue or GitHub operation.
@@ -78,7 +79,8 @@ If this fails for any reason (e.g. the issue is not on a project board, or the s
 3. Replace every run of non-alphanumeric characters with a single hyphen.
 4. Strip any leading or trailing hyphens.
 5. Truncate the resulting slug to 50 characters.
-6. Prepend the issue number: `<N>-<slug>`
+6. Strip any trailing hyphen introduced by the truncation cut.
+7. Prepend the issue number: `<N>-<slug>`
 
 Examples:
 - Issue #98 "building-gh-issue commits directly to main — no worktree or branch created" → `98-building-gh-issue-commits-directly-to-main-no`
@@ -92,7 +94,11 @@ Examples:
 
 This phase runs **unconditionally** — regardless of the branch that is currently checked out.
 
-**This phase is fatal.** If `using-git-worktrees` fails for any reason, stop the build immediately with a clear error. Do not log-and-continue.
+**This phase is fatal.** If `using-git-worktrees` fails for any reason, stop the build immediately with:
+
+> "❌ Phase 3 blocked: `superpowers:using-git-worktrees` failed. Resolve the Git error above before retrying the build."
+
+Do not log-and-continue.
 
 ### Phase 4 — Execute plan
 
@@ -159,27 +165,30 @@ If the skill is not available, **stop immediately** with:
 > "❌ Phase 9 blocked: `token-effort:recording-decisions` skill is required but not available.
 >  Install the skill before continuing the build."
 
-Do not proceed to Phase 9 until this phase completes successfully.
+Do not proceed to Phase 10 until this phase completes successfully.
 
 ### Phase 10 — Finish development branch
 
 Invoke: `superpowers:finishing-a-development-branch`
 
-This step creates the pull request. It runs exactly once, here, at the end of the build process. The execution skills in Phase 3 must not call it — that is what the suppression instruction in Phase 3 enforces.
+This step creates the pull request. It runs exactly once, here, at the end of the build process. The execution skills in Phase 4 must not call it — that is what the suppression instruction in Phase 4 enforces.
 
 ## Common Mistakes
 
 - **Blocking on Phase 2 failure** — `move-issue-status` errors are non-fatal. Log the warning and continue. Never stop the build because of a status update failure.
 - **Proceeding without a plan comment** — if `<!-- token-effort:planning-gh-issue -->` is not found in the issue, abort immediately with the message to run `/token-effort:planning-gh-issue #N` first. Do not proceed to execution without an approved plan.
-- **Omitting the suppression instruction from the Phase 3 prompt** — the verbatim instruction `"Do not invoke finishing-a-development-branch — this will be handled by the calling skill after all review steps complete."` must be included in the execution skill invocation. Paraphrasing it or omitting it is incorrect.
-- **Calling `finishing-a-development-branch` inside the Phase 3 execution skill** — the PR creation step belongs at Phase 9 and only there. The suppression instruction in Phase 3 enforces this; do not override it.
+- **Omitting the suppression instruction from the Phase 4 prompt** — the verbatim instruction `"Do not invoke finishing-a-development-branch — this will be handled by the calling skill after all review steps complete."` must be included in the execution skill invocation. Paraphrasing it or omitting it is incorrect.
+- **Calling `finishing-a-development-branch` inside the Phase 4 execution skill** — the PR creation step belongs at Phase 10 and only there. The suppression instruction in Phase 4 enforces this; do not override it.
 - **Choosing `executing-plans` for non-trivial scope plans** — the default is `subagent-driven-development`. Only switch to `executing-plans` when all conditions (single-step plan, no more than 2 files touched) are met simultaneously.
-- **Silently skipping Phase 4** — Phase 4 is optional but must log a named warning when skipped. Do not silently continue without the warning.
-- **Continuing past Phase 8 when `recording-decisions` is unavailable** — Phase 8 is a hard block. If the skill is not installed, stop with the error message. Do not warn and continue.
+- **Silently skipping Phase 5** — Phase 5 is optional but must log a named warning when skipped. Do not silently continue without the warning.
+- **Continuing past Phase 9 when `recording-decisions` is unavailable** — Phase 9 is a hard block. If the skill is not installed, stop with the error message. Do not warn and continue.
 - **Passing the full raw comment body to the execution skill** — strip both the `<!-- brainstorming-gh-issue:spec -->` and `<!-- token-effort:planning-gh-issue -->` marker lines before using their content. Do not include markers in the context.
 - **Not stripping the leading `#` from the issue number** — `gh issue view` requires a bare integer. Strip any `#` prefix before constructing the command.
 - **Using MCP tools for issue operations** — all GitHub interactions must use `gh` CLI commands. Never call `mcp__plugin_github_github__*` tools for any operation.
-- **Calling `finishing-a-development-branch` more than once** — it must be called exactly once, at Phase 9, regardless of how many execution iterations Phase 3 required.
+- **Calling `finishing-a-development-branch` more than once** — it must be called exactly once, at Phase 10, regardless of how many execution iterations Phase 4 required.
+- **Skipping Phase 3 when already on a feature branch** — Phase 3 always runs. Do not inspect the current branch name and conditionally skip worktree creation.
+- **Letting `using-git-worktrees` prompt the user for a worktree location** — the path `.claude/worktrees/<branch-name>` must be supplied in the invocation prompt so the skill's interactive directory-selection flow is bypassed.
+- **Treating Phase 3 failure as non-fatal** — unlike Phase 2, a failed worktree creation must stop the build immediately. Do not log a warning and continue.
 
 ## Eval
 
@@ -191,6 +200,11 @@ This step creates the pull request. It runs exactly once, here, at the end of th
 - [ ] Blocked with clear error when plan comment not found
 - [ ] Called `token-effort:move-issue-status <N> "Building"` in Phase 2
 - [ ] Phase 2 failure logged as a warning and did not block the build
+- [ ] Phase 3 invoked before the execution skill (Phase 4)
+- [ ] Branch name derived as `<N>-<slug>` from issue number and title (lowercase, non-alphanumeric → hyphens, slug ≤ 50 chars)
+- [ ] `superpowers:using-git-worktrees` invoked with `.claude/worktrees/<branch-name>` as the supplied path
+- [ ] Phase 3 failure stops the build (not logged and continued)
+- [ ] Phase 3 runs even when the current branch is not `main`
 - [ ] Assessed plan complexity before choosing execution skill
 - [ ] Used `subagent-driven-development` by default; `executing-plans` only when all conditions apply
 - [ ] Plan content (marker stripped) passed to execution skill as context
@@ -202,6 +216,6 @@ This step creates the pull request. It runs exactly once, here, at the end of th
 - [ ] Performed inline security review after code review; reported a summary
 - [ ] Invoked `token-effort:recording-decisions` and blocked with error message if not available
 - [ ] Did not proceed to Phase 9 when `recording-decisions` was unavailable
-- [ ] Invoked `superpowers:finishing-a-development-branch` exactly once, at Phase 9
-- [ ] `finishing-a-development-branch` was NOT called by the execution skills in Phase 3
+- [ ] Invoked `superpowers:finishing-a-development-branch` exactly once, at Phase 10
+- [ ] `finishing-a-development-branch` was NOT called by the execution skills in Phase 4
 - [ ] No MCP tools used at any point

--- a/plugins/token-effort/skills/building-gh-issue/SKILL.md
+++ b/plugins/token-effort/skills/building-gh-issue/SKILL.md
@@ -61,7 +61,7 @@ gh issue view <N> --json number,title,body,comments,labels
 
 > "Issue #N does not have an implementation plan comment. Run `/token-effort:planning-gh-issue <N>` to generate one, then get it approved before building."
 
-**If found:** Extract the plan body — the full comment content **after** stripping the `<!-- token-effort:planning-gh-issue -->` marker line. This is the plan used for execution in Phase 3.
+**If found:** Extract the plan body — the full comment content **after** stripping the `<!-- token-effort:planning-gh-issue -->` marker line. This is the plan used for execution in Phase 4.
 
 ### Phase 2 — Move issue to Building status
 
@@ -69,7 +69,32 @@ Invoke: `token-effort:move-issue-status <N> "Building"`
 
 If this fails for any reason (e.g. the issue is not on a project board, or the skill is unavailable), **log a warning and continue**. This phase is non-fatal — do not block the build on a status update failure.
 
-### Phase 3 — Execute plan
+### Phase 3 — Create worktree
+
+**Branch naming:** Derive the branch name from the issue data extracted in Phase 1:
+
+1. Take the issue title.
+2. Lowercase it.
+3. Replace every run of non-alphanumeric characters with a single hyphen.
+4. Strip any leading or trailing hyphens.
+5. Truncate the resulting slug to 50 characters.
+6. Prepend the issue number: `<N>-<slug>`
+
+Examples:
+- Issue #98 "building-gh-issue commits directly to main — no worktree or branch created" → `98-building-gh-issue-commits-directly-to-main-no`
+- Issue #55 "Add retry logic to the API client — handles 5xx errors" → `55-add-retry-logic-to-the-api-client-handles-5xx`
+
+**Worktree creation:** Invoke `superpowers:using-git-worktrees` with the following context supplied in the prompt:
+
+- **Worktree path:** `.claude/worktrees/<branch-name>`
+- **Branch name:** `<branch-name>` (as derived above)
+- **Instruction:** use the supplied path and branch name directly; skip the interactive directory-selection flow
+
+This phase runs **unconditionally** — regardless of the branch that is currently checked out.
+
+**This phase is fatal.** If `using-git-worktrees` fails for any reason, stop the build immediately with a clear error. Do not log-and-continue.
+
+### Phase 4 — Execute plan
 
 Assess the plan extracted in Phase 1. Choose the execution skill:
 
@@ -84,17 +109,17 @@ Invoke the chosen skill with the plan content injected as context, and the follo
 
 This instruction is required regardless of which execution skill is chosen. Do not paraphrase or omit it.
 
-### Phase 4 — Verify (optional)
+### Phase 5 — Verify (optional)
 
 Attempt to invoke the project-local `/verify` skill.
 
 If `/verify` is not available or not found, log the following named warning and continue:
 
-> "⚠️ Phase 4 skipped: `/verify` skill not available in this project"
+> "⚠️ Phase 5 skipped: `/verify` skill not available in this project"
 
 Do not block on this phase.
 
-### Phase 5 — Inline simplify pass
+### Phase 6 — Inline simplify pass
 
 Review all changed code directly using Claude's built-in reasoning. No separate skill invocation is needed.
 
@@ -106,13 +131,13 @@ Check for:
 
 Fix any issues found directly. Report a brief summary of changes made, or "No changes needed" if nothing required fixing.
 
-### Phase 6 — Code review
+### Phase 7 — Code review
 
 Invoke: `token-effort:reviewing-code-systematically`
 
-Address any `BLOCK` or `NEEDS_CHANGES` findings before continuing to Phase 7.
+Address any `BLOCK` or `NEEDS_CHANGES` findings before continuing to Phase 8.
 
-### Phase 7 — Inline security review
+### Phase 8 — Inline security review
 
 Review all changed code directly using Claude's built-in reasoning. No separate skill invocation is needed.
 
@@ -125,18 +150,18 @@ Check for:
 
 Fix any issues found directly. Report a brief summary of findings, or "No security issues found" if the review was clean.
 
-### Phase 8 — Record decisions
+### Phase 9 — Record decisions
 
 Invoke: `token-effort:recording-decisions`
 
 If the skill is not available, **stop immediately** with:
 
-> "❌ Phase 8 blocked: `token-effort:recording-decisions` skill is required but not available.
+> "❌ Phase 9 blocked: `token-effort:recording-decisions` skill is required but not available.
 >  Install the skill before continuing the build."
 
 Do not proceed to Phase 9 until this phase completes successfully.
 
-### Phase 9 — Finish development branch
+### Phase 10 — Finish development branch
 
 Invoke: `superpowers:finishing-a-development-branch`
 
@@ -173,7 +198,7 @@ This step creates the pull request. It runs exactly once, here, at the end of th
 - [ ] Attempted `/verify` and skipped with named warning if absent
 - [ ] Performed inline simplify pass after verify; reported a summary
 - [ ] Invoked `token-effort:reviewing-code-systematically`
-- [ ] Addressed BLOCK or NEEDS_CHANGES findings before continuing past Phase 6
+- [ ] Addressed BLOCK or NEEDS_CHANGES findings before continuing past Phase 7
 - [ ] Performed inline security review after code review; reported a summary
 - [ ] Invoked `token-effort:recording-decisions` and blocked with error message if not available
 - [ ] Did not proceed to Phase 9 when `recording-decisions` was unavailable

--- a/training/skills/building-gh-issue/always-creates-worktree.md
+++ b/training/skills/building-gh-issue/always-creates-worktree.md
@@ -1,0 +1,13 @@
+## Scenario
+
+The user runs `/token-effort:building-gh-issue 98` while already checked out on `feature/other-thing`. Valid spec and plan comments exist.
+
+## Expected Behaviour
+
+- Phase 3 still invokes `superpowers:using-git-worktrees` with the derived path `.claude/worktrees/98-<slug>`.
+- No branch-detection logic skips the phase.
+
+## Pass Criteria
+
+- [ ] `using-git-worktrees` is invoked regardless of the current branch.
+- [ ] No conditional branch-name check precedes Phase 3.

--- a/training/skills/building-gh-issue/calls-move-issue-status-building.md
+++ b/training/skills/building-gh-issue/calls-move-issue-status-building.md
@@ -5,8 +5,8 @@ The user runs `/token-effort:building-gh-issue 22`. The issue has a valid spec c
 ## Expected Behaviour
 
 - Phase 1 fetches the issue, finds both the spec and plan comments, and strips their respective marker lines.
-- Phase 2 calls `token-effort:move-issue-status 22 "Building"` before Phase 3 begins.
-- Phase 3 invokes the execution skill with the stripped plan body as context.
+- Phase 2 calls `token-effort:move-issue-status 22 "Building"` before Phase 4 begins.
+- Phase 4 invokes the execution skill with the stripped plan body as context.
 
 ## Pass Criteria
 
@@ -14,5 +14,5 @@ The user runs `/token-effort:building-gh-issue 22`. The issue has a valid spec c
 - [ ] The spec comment is found via its `<!-- brainstorming-gh-issue:spec -->` marker.
 - [ ] The plan comment is found via its `<!-- token-effort:planning-gh-issue -->` marker.
 - [ ] `token-effort:move-issue-status 22 "Building"` is called in Phase 2.
-- [ ] The execution skill is invoked in Phase 3 AFTER `token-effort:move-issue-status`.
+- [ ] The execution skill is invoked in Phase 4 AFTER `token-effort:move-issue-status`.
 - [ ] The plan body passed to the execution skill does NOT include the `<!-- token-effort:planning-gh-issue -->` marker line.

--- a/training/skills/building-gh-issue/creates-worktree-before-execution.md
+++ b/training/skills/building-gh-issue/creates-worktree-before-execution.md
@@ -1,0 +1,15 @@
+## Scenario
+
+The user runs `/token-effort:building-gh-issue 98` while `main` is checked out. Issue #98 has valid spec and plan comments.
+
+## Expected Behaviour
+
+- Phase 2 moves the issue to Building status.
+- Phase 3 invokes `superpowers:using-git-worktrees` with worktree path `.claude/worktrees/98-building-gh-issue-commits-directly-to-main-no` before any execution skill is called.
+- Phase 4 (execution) does not begin until Phase 3 completes.
+
+## Pass Criteria
+
+- [ ] `using-git-worktrees` is invoked before the execution skill.
+- [ ] Worktree path begins with `.claude/worktrees/98-`.
+- [ ] Execution skill is not invoked until after Phase 3 completes.

--- a/training/skills/building-gh-issue/default-to-subagent-driven-development.md
+++ b/training/skills/building-gh-issue/default-to-subagent-driven-development.md
@@ -4,13 +4,13 @@ The user runs `/token-effort:building-gh-issue 55`. Valid spec and plan comments
 
 ## Expected Behaviour
 
-- Phase 3 assesses plan complexity before choosing an execution skill.
+- Phase 4 assesses plan complexity before choosing an execution skill.
 - The plan is determined to be of non-trivial scope (either more than one step and/or >2 files modified)
-- `superpowers:subagent-driven-development` is chosen for Phase 3.
+- `superpowers:subagent-driven-development` is chosen for Phase 4.
 - `superpowers:executing-plans` is NOT invoked.
 
 ## Pass Criteria
 
-- [ ] Plan complexity is assessed before Phase 3 execution begins.
-- [ ] `superpowers:subagent-driven-development` is invoked for Phase 3.
+- [ ] Plan complexity is assessed before Phase 4 execution begins.
+- [ ] `superpowers:subagent-driven-development` is invoked for Phase 4.
 - [ ] `superpowers:executing-plans` is NOT invoked.

--- a/training/skills/building-gh-issue/derives-branch-name-from-issue.md
+++ b/training/skills/building-gh-issue/derives-branch-name-from-issue.md
@@ -1,0 +1,14 @@
+## Scenario
+
+The user runs `/token-effort:building-gh-issue 55`. Issue #55 has title "Add retry logic to the API client — handles 5xx errors". Valid spec and plan comments exist.
+
+## Expected Behaviour
+
+- Phase 3 derives the branch name as `55-add-retry-logic-to-the-api-client-handles-5xx`.
+- The title is lowercased, non-alphanumeric runs are replaced with single hyphens, and the slug is truncated to 50 characters before prepending the issue number.
+
+## Pass Criteria
+
+- [ ] Branch name starts with `55-`.
+- [ ] The slug contains only lowercase letters, digits, and hyphens (no uppercase letters, spaces, or other characters).
+- [ ] Slug portion does not exceed 50 characters.

--- a/training/skills/building-gh-issue/skips-verify-with-warning.md
+++ b/training/skills/building-gh-issue/skips-verify-with-warning.md
@@ -1,16 +1,16 @@
 ## Scenario
 
-The user runs `/token-effort:building-gh-issue 44`. Valid spec and plan comments exist and the plan executes successfully through Phase 3. In Phase 4, the skill attempts to invoke `/verify`, but the skill is not available in this project.
+The user runs `/token-effort:building-gh-issue 44`. Valid spec and plan comments exist and the plan executes successfully through Phase 4. In Phase 5, the skill attempts to invoke `/verify`, but the skill is not available in this project.
 
 ## Expected Behaviour
 
-- Phase 4 attempts to invoke `/verify`.
-- Because `/verify` is unavailable, a named warning is logged: "⚠️ Phase 4 skipped: `/verify` skill not available in this project".
-- Execution continues without stopping; Phase 5 (inline simplify pass) runs next.
+- Phase 5 attempts to invoke `/verify`.
+- Because `/verify` is unavailable, a named warning is logged: "⚠️ Phase 5 skipped: `/verify` skill not available in this project".
+- Execution continues without stopping; Phase 6 (inline simplify pass) runs next.
 
 ## Pass Criteria
 
-- [ ] An attempt to invoke `/verify` is made in Phase 4.
-- [ ] A named warning is logged that includes both "Phase 4 skipped" and "/verify".
+- [ ] An attempt to invoke `/verify` is made in Phase 5.
+- [ ] A named warning is logged that includes both "Phase 5 skipped" and "/verify".
 - [ ] Execution does NOT stop or error out after the warning.
-- [ ] Phase 5 (inline simplify pass) runs after the warning is logged.
+- [ ] Phase 6 (inline simplify pass) runs after the warning is logged.

--- a/training/skills/building-gh-issue/suppresses-finishing-branch.md
+++ b/training/skills/building-gh-issue/suppresses-finishing-branch.md
@@ -4,13 +4,13 @@ The user runs `/token-effort:building-gh-issue 31`. Valid spec and plan comments
 
 ## Expected Behaviour
 
-- Phase 3 invokes `superpowers:subagent-driven-development` with the verbatim suppression instruction embedded in the prompt: "Do not invoke `finishing-a-development-branch` — this will be handled by the calling skill after all review steps complete."
+- Phase 4 invokes `superpowers:subagent-driven-development` with the verbatim suppression instruction embedded in the prompt: "Do not invoke `finishing-a-development-branch` — this will be handled by the calling skill after all review steps complete."
 - `subagent-driven-development` respects the suppression and does NOT call `superpowers:finishing-a-development-branch` internally.
-- `superpowers:finishing-a-development-branch` is called exactly once, at Phase 9, after all review steps complete.
+- `superpowers:finishing-a-development-branch` is called exactly once, at Phase 10, after all review steps complete.
 
 ## Pass Criteria
 
-- [ ] `superpowers:subagent-driven-development` is chosen for Phase 3 (not `superpowers:executing-plans`).
+- [ ] `superpowers:subagent-driven-development` is chosen for Phase 4 (not `superpowers:executing-plans`).
 - [ ] The invocation prompt for `superpowers:subagent-driven-development` contains the exact text: "Do not invoke `finishing-a-development-branch` — this will be handled by the calling skill after all review steps complete."
-- [ ] `superpowers:finishing-a-development-branch` is NOT called during or inside Phase 3.
-- [ ] `superpowers:finishing-a-development-branch` is called exactly once, at Phase 9.
+- [ ] `superpowers:finishing-a-development-branch` is NOT called during or inside Phase 4.
+- [ ] `superpowers:finishing-a-development-branch` is called exactly once, at Phase 10.

--- a/training/skills/building-gh-issue/trivial-change-inline-execution.md
+++ b/training/skills/building-gh-issue/trivial-change-inline-execution.md
@@ -4,13 +4,13 @@ The user runs `/token-effort:building-gh-issue 42`. Valid spec and plan comments
 
 ## Expected Behaviour
 
-- Phase 3 assesses plan complexity before choosing an execution skill.
+- Phase 4 assesses plan complexity before choosing an execution skill.
 - The plan is determined to be of trivial scope (a single step, with only <=2 files modified).
-- `superpowers:executing-plans` is chosen for Phase 3.
+- `superpowers:executing-plans` is chosen for Phase 4.
 - `superpowers:subagent-driven-development` is NOT invoked.
 
 ## Pass Criteria
 
-- [ ] Plan complexity is assessed before Phase 3 execution begins.
-- [ ] `superpowers:executing-plans` is invoked for Phase 3.
+- [ ] Plan complexity is assessed before Phase 4 execution begins.
+- [ ] `superpowers:executing-plans` is invoked for Phase 4.
 - [ ] `superpowers:subagent-driven-development` is NOT invoked.

--- a/training/skills/building-gh-issue/worktree-creation-is-fatal.md
+++ b/training/skills/building-gh-issue/worktree-creation-is-fatal.md
@@ -1,0 +1,15 @@
+## Scenario
+
+The user runs `/token-effort:building-gh-issue 98`. Valid spec and plan comments exist. `superpowers:using-git-worktrees` fails (e.g. a Git error or path conflict).
+
+## Expected Behaviour
+
+- Phase 3 invokes `using-git-worktrees`, which fails.
+- The build stops immediately with a clear error.
+- No execution skill is invoked.
+
+## Pass Criteria
+
+- [ ] Build stops after Phase 3 failure.
+- [ ] Execution skill is NOT invoked.
+- [ ] No warning-and-continue pattern is used.


### PR DESCRIPTION
## Summary

- Inserts mandatory Phase 3 ("Create worktree") into `building-gh-issue` before the execution skill runs, so implementation work is never committed directly to `main`
- Branch name is derived deterministically as `<N>-<slug>` (lowercased, hyphenated, ≤50-char title slug) and a worktree is created at `.claude/worktrees/<branch-name>` via `superpowers:using-git-worktrees`
- All subsequent phases renumbered 4–10; three new Common Mistakes entries, five new Eval criteria, and `superpowers:using-git-worktrees` added to Prerequisites

## Test Plan

- [ ] Run `/token-effort:building-gh-issue <N>` on a repo where `main` is checked out — verify a worktree is created at `.claude/worktrees/<N>-<slug>` before the execution skill fires
- [ ] Verify Phase 3 runs even when already on a feature branch (not just `main`)
- [ ] Verify a `using-git-worktrees` failure stops the build with `❌ Phase 3 blocked: ...` (not a warning-and-continue)
- [x] Check training evals pass against the updated skill definition

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)