### PR TITLE
Block move when pending-review label is present (#69)

### DIFF
--- a/docs/decisions/2026-05-block-moving-on-pending-review.md
+++ b/docs/decisions/2026-05-block-moving-on-pending-review.md
@@ -1,0 +1,26 @@
+# 2026-05-block-moving-on-pending-review
+
+> **Status:** Active
+> **Issue:** [#69 — Block moving an issue to "next" status when `pending-review` label is present](https://github.com/HeadlessTarry/Token-Effort/issues/69)
+> **Date:** 2026-05-03
+
+## Context
+
+Various skills can move a GitHub issue to the "next" status on a project board (e.g., `/brainstorming-gh-issue`, `/planning-gh-issue`, `/building-gh-issue`). The `pending-review` label is used to flag when an issue requires manual approval before continuing. When an issue carries this label, no AI agent should advance it — only a human can unblock progress by removing the label.
+
+Today, there is no enforcement point: a skill can move an issue to "next" regardless of the `pending-review` label. This creates a gap where automated workflows bypass the human review gate.
+
+## Decision
+
+Add a `has_pending_review_label()` check at the top of `run()` in `move_issue_status.py`. If the label is present, the script returns `{"status": "blocked", "issue": N, "reason": "pending-review"}` immediately, before any project board lookup.
+
+The check is placed in the enforcement point (`move_issue_status.py`), not in the skill wrapper, so all callers (skills, GitHub Actions, future automation) are protected uniformly.
+
+Update `SKILL.md` to document the `"blocked"` status and warn against treating it silently. Add training evals for both script-level and skill-level blocked behaviour to ensure skills handle the response correctly.
+
+## Consequences
+
+- The check runs before `resolve_repo()`, so it calls `gh issue view` without an explicit `--repo` flag (relies on ambient git remote detection). If `gh` fails or returns empty output, the function returns `False` (safe default — allows the move to proceed rather than blocking on tool failure).
+- Only board moves are gated; labelling and commenting are unaffected.
+- Removing the `pending-review` label remains a human-only action.
+- All existing callers of `move_issue_status` (skills and GitHub Actions) now respect the block without code changes, but they should be trained to handle the `"blocked"` response gracefully.

--- a/plugins/workflow/skills/move-issue-status/SKILL.md
+++ b/plugins/workflow/skills/move-issue-status/SKILL.md
@@ -64,6 +64,7 @@ Use the `status` field from the JSON to determine output:
 |----------|--------|
 | `"moved"` | Print: `Moved issue #<issue> to '<to>' in project '<project>'` |
 | `"skipped"` | No output. Stop. |
+| `"blocked"` | Print: `Issue #<issue> has the \`pending-review\` label — a human must remove it before this issue can be advanced.` Stop. |
 | `"error"` | Report the `message` field. Stop. |
 
 ## ⚠️ Common Mistakes
@@ -74,6 +75,7 @@ Use the `status` field from the JSON to determine output:
 - **Treating `status == "error"` as fatal** — report the `message` and stop, but do not raise an exception or block callers.
 - **Passing the `#` prefix to the script** — strip `#` before constructing the command.
 - **Using MCP tools** — all GitHub operations happen inside the Python script via `gh` CLI.
+- **Treating `"blocked"` like `"skipped"` (silent)** — `"blocked"` must always produce a visible message. It is not a no-op; it signals an active human checkpoint.
 
 ## Eval
 
@@ -85,5 +87,7 @@ Use the `status` field from the JSON to determine output:
 - [ ] For `status == "moved"`: printed message with issue number, target status, and project name
 - [ ] For `status == "skipped"`: produced no output
 - [ ] For `status == "error"`: reported the `message` field
+- [ ] For `status == "blocked"`: printed visible message referencing issue number and `pending-review`
+- [ ] For `status == "blocked"`: did NOT treat it as `"skipped"` (silent)
 - [ ] No MCP tools used
 - [ ] No `${...}` shell expansion used

--- a/plugins/workflow/skills/move-issue-status/move_issue_status.py
+++ b/plugins/workflow/skills/move-issue-status/move_issue_status.py
@@ -79,6 +79,8 @@ def has_pending_review_label(issue_number: int) -> bool:
         ["gh", "issue", "view", str(issue_number), "--json", "labels"],
         capture_output=True, text=True, encoding="utf-8",
     )
+    if result.returncode != 0 or not result.stdout.strip():
+        return False
     data = json.loads(result.stdout)
     return any(label.get("name") == "pending-review" for label in data.get("labels", []))
 

--- a/plugins/workflow/skills/move-issue-status/move_issue_status.py
+++ b/plugins/workflow/skills/move-issue-status/move_issue_status.py
@@ -1,6 +1,7 @@
 """Move a GitHub issue to a named project board status column.
 
 Outputs a single JSON line to stdout. Exit code is always 0.
+Returns {"status": "blocked"} without touching the board when the issue carries a pending-review label.
 """
 import json
 import os
@@ -76,7 +77,7 @@ def get_status_field(owner: str, project_number: int) -> dict | None:
 
 def has_pending_review_label(issue_number: int) -> bool:
     result = subprocess.run(
-        ["gh", "issue", "view", str(issue_number), "--json", "labels"],
+        ["gh", "issue", "view", str(issue_number), "--json", "labels"],  # relies on gh's ambient repo detection from the local git remote
         capture_output=True, text=True, encoding="utf-8",
     )
     if result.returncode != 0 or not result.stdout.strip():
@@ -87,7 +88,7 @@ def has_pending_review_label(issue_number: int) -> bool:
 
 def run(issue_number: int, target_status: str | None) -> dict:
     if has_pending_review_label(issue_number):
-        return {"status": "blocked", "issue": issue_number}
+        return {"status": "blocked", "issue": issue_number, "reason": "pending-review"}
     owner, _repo = resolve_repo()  # gh project commands use owner only
     matches = find_project_item(owner, issue_number)
 

--- a/plugins/workflow/skills/move-issue-status/move_issue_status.py
+++ b/plugins/workflow/skills/move-issue-status/move_issue_status.py
@@ -74,7 +74,18 @@ def get_status_field(owner: str, project_number: int) -> dict | None:
     return None
 
 
+def has_pending_review_label(issue_number: int) -> bool:
+    result = subprocess.run(
+        ["gh", "issue", "view", str(issue_number), "--json", "labels"],
+        capture_output=True, text=True, encoding="utf-8",
+    )
+    data = json.loads(result.stdout)
+    return any(label.get("name") == "pending-review" for label in data.get("labels", []))
+
+
 def run(issue_number: int, target_status: str | None) -> dict:
+    if has_pending_review_label(issue_number):
+        return {"status": "blocked", "issue": issue_number}
     owner, _repo = resolve_repo()  # gh project commands use owner only
     matches = find_project_item(owner, issue_number)
 

--- a/training/workflow/skills/move-issue-status/handles-blocked-with-message.md
+++ b/training/workflow/skills/move-issue-status/handles-blocked-with-message.md
@@ -1,0 +1,15 @@
+## Scenario
+
+The `move_issue_status.py` script returns `{"status": "blocked", "issue": 42}`.
+
+## Expected Behavior
+
+The skill prints a visible message referencing the issue number and mentioning `pending-review`. It does not produce a "moved" result, does not skip silently, and does not emit a generic error.
+
+## Pass Criteria
+
+- [ ] Printed a visible message referencing the issue number
+- [ ] Message mentions `pending-review`
+- [ ] Did NOT produce a `"moved"` or silent result
+- [ ] Did NOT treat it as `"skipped"` (no output)
+- [ ] Did NOT treat it as `"error"` (no generic error message)

--- a/training/workflow/skills/move-issue-status/script-blocks-when-pending-review-label-present.md
+++ b/training/workflow/skills/move-issue-status/script-blocks-when-pending-review-label-present.md
@@ -1,0 +1,15 @@
+## Scenario
+
+`gh issue view --json labels` returns labels including `pending-review` for the given issue.
+
+## Expected Behavior
+
+The script returns `{"status": "blocked", "issue": N}` without calling any project board commands.
+
+## Pass Criteria
+
+- [ ] Called `gh issue view --json labels` for the issue
+- [ ] Detected `pending-review` in the labels array
+- [ ] Returned `{"status": "blocked", "issue": <N>}` with exit code 0
+- [ ] Did NOT call `gh project item-list`, `gh project field-list`, or `gh project item-edit`
+- [ ] Exit code is 0

--- a/training/workflow/skills/move-issue-status/script-blocks-when-pending-review-label-present.md
+++ b/training/workflow/skills/move-issue-status/script-blocks-when-pending-review-label-present.md
@@ -4,12 +4,12 @@
 
 ## Expected Behavior
 
-The script returns `{"status": "blocked", "issue": N}` without calling any project board commands.
+The script returns `{"status": "blocked", "issue": N, "reason": "pending-review"}` without calling any project board commands.
 
 ## Pass Criteria
 
 - [ ] Called `gh issue view --json labels` for the issue
 - [ ] Detected `pending-review` in the labels array
-- [ ] Returned `{"status": "blocked", "issue": <N>}` with exit code 0
+- [ ] Returned `{"status": "blocked", "issue": <N>, "reason": "pending-review"}` with exit code 0
 - [ ] Did NOT call `gh project item-list`, `gh project field-list`, or `gh project item-edit`
 - [ ] Exit code is 0


### PR DESCRIPTION
## Summary

- Adds `has_pending_review_label()` guard at the top of `run()` in `move_issue_status.py` — returns `{"status": "blocked", "issue": N, "reason": "pending-review"}` before any project board lookup
- Updates `SKILL.md` Phase 3 table with a `"blocked"` row and adds a Common Mistakes entry distinguishing it from the silent `"skipped"` status
- Adds two training evals for the blocked path: one testing script-level behaviour, one testing skill-level message output

## Test Plan

- [ ] Run `/token-effort-workflow:move-issue-status 69` while issue #69 has `pending-review` label — expect visible blocked message
- [ ] Remove `pending-review` label from a test issue and confirm a normal move still works end-to-end
- [ ] Verify `python plugins/workflow/skills/move-issue-status/move_issue_status.py 69` returns `{"status": "blocked", ...}` while label is present

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)