### PR TITLE
feat: add job summary to release workflow (#94)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,11 @@ jobs:
           gh release create "v$VERSION" \
             --generate-notes \
             --title "v$VERSION"
+
+      - name: 🎉 Summarise release
+        run: |
+          echo "## 🎉 Release Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** v$VERSION" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Link:** [View release on GitHub](https://github.com/${{ github.repository }}/releases/tag/v$VERSION)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Adds a `🎉 Summarise release` step to the `release` job in `.github/workflows/release.yml`
- Writes a formatted markdown block to `$GITHUB_STEP_SUMMARY` after the release is published
- Surfaces the version number and a direct link to the new release on the workflow run summary page

## Test Plan

- [ ] Trigger a release via Actions → Release → Run workflow with a valid SemVer version
- [ ] Verify the workflow run summary page shows the `🎉 Release Published` block with correct version and link

Closes #94