### PR TITLE
feat: migrate run-training skill to OpenCode

### DIFF
--- a/.opencode/skills/run-training/SKILL.md
+++ b/.opencode/skills/run-training/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: run-training
+description: Use when the user wants to iteratively improve a skill or agent definition through automated evaluation cycles against committed test cases.
+user-invocable: true
+---
+
+# Training: Iterative Skill/Agent Improvement
+
+## Overview
+
+Applies the [Karpathy "autoresearch" pattern](https://github.com/karpathy/autoresearch) to skill and agent definitions. Instead of tweaking ML training code, it mutates `SKILL.md` / agent `.md` files and scores each candidate against committed eval cases. Run for a single cycle (manual) or many cycles (autonomous).
+
+**Usage:** `/run-training skills/<name>/SKILL.md` or `/run-training agents/<name>.md`
+
+> **Note:** The old shorthand forms (`/run-training <name>` and `/run-training agent:<name>`) are no longer supported. Always supply the full path.
+
+## Phase 1 — Target
+
+Resolve paths from the user's argument by parsing the type and name from the supplied path:
+
+| Input | Type | Name | Definition file | Evals directory |
+|-------|------|------|----------------|-----------------|
+| `skills/brainstorming-gh-issue/SKILL.md` | `skills` | `brainstorming-gh-issue` | `skills/brainstorming-gh-issue/SKILL.md` | `training/skills/brainstorming-gh-issue/` |
+| `agents/skill-creator-engineer.md` | `agents` | `skill-creator-engineer` | `agents/skill-creator-engineer.md` | `training/agents/skill-creator-engineer/` |
+
+Parse rules:
+- **Definition file**: the argument as supplied verbatim
+- **Type**: first path segment — `skills` or `agents`
+- **Name**: for skills, the second path segment; for agents, the filename without `.md`
+- **Evals directory**: `training/<type>/<name>/`
+
+If the definition file is missing, **stop and report the error**. Do not proceed.
+
+## Phase 2 — Eval Setup
+
+- **No `.md` eval files exist** in `training/<type>/<name>/` (excluding `.training-results/`): auto-generate 3–5 starter eval cases from the definition. Display them to the user. **Wait for approval/edits before continuing.**
+- **Evals already exist**: load all `.md` files from `training/<type>/<name>/` (excluding `.training-results/`). Report count to user.
+
+### Eval filename conventions
+
+When writing auto-generated eval files, names must:
+- Use lowercase hyphenated words (e.g., `missing-definition.md`, `score-no-improvement.md`)
+- Not start with a number
+- End with `.md`
+
+### Eval file format
+
+Plain markdown, no frontmatter:
+
+```markdown
+## Scenario
+[Input context]
+
+## Expected Behavior
+[What the skill/agent should do]
+
+## Pass Criteria
+- [ ] Criterion 1 (binary yes/no)
+- [ ] Criterion 2
+```
+
+## Phase 3 — Baseline
+
+1. **Clean up any previous run.** If `training/<type>/<name>/.training-results/` already exists, delete the entire directory and inform the user: "Removed stale `.training-results/` directory from a previous run." This prevents old state, candidates, or results from polluting the new session.
+2. Read the current definition file.
+3. For each eval file, simulate the scenario against the current definition: mark each pass criterion ✓ (pass) or ✗ (fail).
+4. Score = criteria passed / total criteria across all evals.
+5. Write initial state to `training/<type>/<name>/.training-results/state.json`:
+   ```json
+   {
+     "iteration": 0,
+     "baseline_score": <score>,
+     "best_score": <score>,
+     "cycles_without_improvement": 0
+   }
+   ```
+6. Copy current definition to `training/<type>/<name>/.training-results/best.md`.
+7. Report baseline score to user.
+8. **If baseline score is 1.0**, trigger the human gate immediately before entering the loop. Show the gate summary and ask: **continue**, **stop**, or **adjust**.
+
+## Phase 4 — Training Loop
+
+**Each cycle:**
+
+1. Load state from `training/<type>/<name>/.training-results/state.json`. **Never trust memory — always read from disk.**
+2. Load all eval files from `training/<type>/<name>/` (excluding `.training-results/`).
+3. Read `training/<type>/<name>/.training-results/best.md` as the starting point.
+4. Apply one mutation operator to produce a candidate definition (hold in memory — do not write to the live file). **Before applying the mutation, state which operator you are choosing and explain why it addresses the observed failure pattern.**
+
+   | Operator | When to use |
+   |----------|-------------|
+   | `add-constraint` | A rule that prevents an observed failure |
+   | `add-example` | A concrete correct-behavior example |
+   | `tighten-language` | Replace ambiguous wording with precise instructions |
+   | `restructure` | Reorder steps/sections for clearer execution |
+   | `add-negative-example` | Explicit "do NOT do X" case |
+   | `remove-bloat` | Trim contradictory or redundant instructions |
+
+   Select the operator based on failure patterns from the previous cycle. On cycle 1, analyse baseline eval results to choose. **Do not reuse the same operator as the previous cycle if that cycle was not kept — a repeated operator against the same failure pattern is unlikely to score higher.**
+
+5. Evaluate the candidate: for each eval, mark each pass criterion ✓/✗.
+6. Score the candidate: criteria passed / total criteria.
+7. Compare candidate score against `best_score` from `state.json`:
+   - **Score improved**: overwrite `best.md` with candidate, update `best_score`, reset `cycles_without_improvement` to 0. Mark as **kept**.
+   - **Score did not improve**: discard candidate, increment `cycles_without_improvement`. Mark as **reverted**.
+   - **The live definition file is NEVER modified during the loop.**
+8. Append to `training/<type>/<name>/.training-results/results.jsonl`:
+   ```
+   {"iteration": N, "score": X.XX, "best_score": X.XX, "operator": "add-constraint", "kept": true/false, "failed_criteria": ["criterion text", ...]}
+   ```
+9. Increment `iteration` in `state.json`.
+10. **Human gate** — pause if any condition is met:
+    - Score has reached 1.0 - i.e. no further improvement to be made against current set of evals
+    - Every 5 cycles completed
+    - 3 consecutive cycles with no improvement (`cycles_without_improvement >= 3`)
+
+    Show summary table:
+    ```
+    | Cycle | Score | Operator       | Kept? |
+    |-------|-------|----------------|-------|
+    | 1     | 0.72  | add-constraint | ✓     |
+    ```
+    Ask: **continue** (run N more cycles), **stop**, or **adjust** (user edits evals or gives guidance). When the user specifies N cycles to continue: run exactly N cycles, then pause at the human gate again — regardless of the 5-cycle boundary.
+
+## Phase 5 — Completion
+
+Report: baseline score → best score, total cycles run, mutations kept vs reverted. Show a diff of `best.md` against the original live definition (which was never modified).
+
+## Phase 6 — Apply (optional)
+
+Ask: "Overwrite `<definition file path>` with the best candidate from this run?"
+
+- **Yes**: write `best.md` → the live definition file. **Write to exactly the path Phase 1 resolved — do not re-resolve, expand, or infer the path from the skill name or a known install location (e.g., `~/.config/opencode/`). The destination is fixed at Phase 1.**
+- **No**: leave the original intact. Inform the user that the best candidate was not applied, and provide both the live definition path and `training/<type>/<name>/.training-results/best.md` so they can apply it manually.
+
+**Never auto-apply without explicit user approval.**
+
+## State Files
+
+All files are gitignored via `training/.gitignore`:
+
+```
+training/<type>/<name>/.training-results/
+├── state.json      ← iteration, best score, cycles-without-improvement
+├── best.md         ← best-scoring candidate seen so far
+└── results.jsonl   ← one entry per cycle
+```
+
+## Common Mistakes
+
+- **Not cleaning up a stale `.training-results/` directory** — always delete it at the start of Phase 3 so old state, candidates, and results cannot carry over into the new session.
+- **Modifying the live definition during the loop** — the loop only ever writes to `.training-results/best.md`.
+- **Trusting in-memory state** — always read `state.json` from disk at the start of each cycle.
+- **Evaluating the live definition during the loop** — always evaluate candidates against `best.md`.
+- **Auto-applying the best candidate** — Phase 6 requires explicit user approval.
+- **Skipping the human gate** — pause at every 5 cycles and at 3 consecutive cycles without improvement.
+- **Re-resolving the apply path in Phase 6** — always write to exactly the path Phase 1 resolved. Never re-resolve, expand, or infer the destination from the skill name or a known install location like `~/.config/opencode/`. The live definition path is determined once in Phase 1 and used verbatim in Phase 6.
+
+## Eval
+
+- [ ] Deleted stale `.training-results/` directory (if present) before writing any new state in Phase 3
+- [ ] Resolved definition path and evals directory correctly for both skill and agent inputs
+- [ ] Stopped and reported error when definition file was missing
+- [ ] Auto-generated starter evals and waited for user approval when no evals existed
+- [ ] Wrote `state.json` with correct initial values before starting the loop
+- [ ] Copied the current definition to `best.md` before the first cycle
+- [ ] Read `state.json` from disk at the start of each cycle (not from memory)
+- [ ] Evaluated candidates against `best.md`, not the live definition file
+- [ ] Never wrote to the live definition file during the loop
+- [ ] Appended a JSONL entry to `results.jsonl` after each cycle
+- [ ] Paused at the human gate every 5 cycles or when `cycles_without_improvement >= 3`
+- [ ] Asked for explicit user approval before overwriting the live definition in Phase 6

--- a/docs/training-guide.md
+++ b/docs/training-guide.md
@@ -1,0 +1,73 @@
+# 🧪 Training Guide
+
+The training system lets you iteratively improve skill and agent definitions by running automated evaluation cycles. It is invoked with the `/run-training` skill.
+
+## Theory
+
+The system implements the [autoresearch pattern](https://github.com/karpathy/autoresearch) described by Andrej Karpathy. The core idea: treat a definition file (skill or agent) as a tunable artefact. Each training cycle proposes a mutation to the definition, evaluates it against a set of committed test cases, and keeps the change only if it improves the score. Over many cycles this converges toward a definition that passes all evals.
+
+## When to Use It
+
+Run training after:
+- Writing or editing a skill or agent definition
+- Adding new eval cases that expose a gap in the current definition
+- Noticing consistent failure modes in real use
+
+## Invoking Training
+
+```bash
+/run-training skills/<name>/SKILL.md  # train a skill
+/run-training agents/<name>.md        # train an agent
+```
+
+Examples:
+```bash
+/run-training skills/triaging-gh-issue/SKILL.md
+/run-training agents/reviewer-docs.md
+```
+
+On the first run for a given skill or agent, training will auto-generate a set of starter eval cases from the definition content, show them to you, and ask for approval before writing any files. You can edit them before approving.
+
+## How It Works
+
+At a high level, training runs through these stages:
+
+1. **Resolve** your input to the definition file and evals directory.
+2. **Load or auto-generate** eval cases.
+3. **Score the current definition** against evals to establish a baseline.
+4. **Iterate**: each cycle mutates the definition, scores the candidate, and keeps the change only if it improves. Human gates pause the loop every 5 cycles, on perfect score, or after 3 consecutive non-improvements.
+5. **Summarise** the run and show a diff of what changed.
+6. **Optionally apply** the best candidate back to the live definition — always with your explicit approval.
+
+The live definition file is never modified during the loop. For full implementation detail, see [`.opencode/skills/run-training/SKILL.md`](../.opencode/skills/run-training/SKILL.md).
+
+## Eval Files
+
+Eval files are plain markdown files committed under `training/skills/<name>/` or `training/agents/<name>/`. They are the ground truth the training loop optimises against.
+
+### Format
+
+```markdown
+## Scenario
+[Describe the situation being tested.]
+
+## Expected Behavior
+[What the skill/agent should do.]
+
+## Pass Criteria
+- [ ] Criterion 1 (binary, testable)
+- [ ] Criterion 2
+- [ ] Criterion 3
+```
+
+### Naming
+
+Lowercase, hyphen-separated: `happy-path.md`, `missing-definition.md`. Must end with `.md`.
+
+### Writing Good Evals
+
+- Each criterion must be binary — pass or fail, no partial credit.
+- Cover the common path, edge cases, and explicit failure modes.
+- Evals with more criteria carry more weight in the overall score.
+- When you notice a real failure in production use, add an eval that would have caught it.
+- Auto-generated starter evals are a starting point — review and extend them.

--- a/training/skills/run-training/agent-definition-path.md
+++ b/training/skills/run-training/agent-definition-path.md
@@ -1,0 +1,9 @@
+## Scenario
+User runs `/run-training agents/reviewer-docs.md`. The file `agents/reviewer-docs.md` exists.
+
+## Expected Behavior
+The skill parses the type (`agents`) and name (`reviewer-docs`) from the supplied path. It resolves the definition file to `agents/reviewer-docs.md` and the evals directory to `training/agents/reviewer-docs/`.
+
+## Pass Criteria
+- [ ] Resolves definition file to `agents/reviewer-docs.md`
+- [ ] Resolves evals directory to `training/agents/reviewer-docs/`

--- a/training/skills/run-training/apply-declined.md
+++ b/training/skills/run-training/apply-declined.md
@@ -1,0 +1,11 @@
+## Scenario
+Phase 5 has completed. `best.md` contains an improved definition that differs from the original live definition. The skill reaches Phase 6 and asks the user whether to apply. The user says "No".
+
+## Expected Behavior
+The skill does not write `best.md` to the live definition file. It informs the user that the best candidate was not applied and tells them both the path of the live definition and the path of `best.md` so they can apply it manually if they choose. `best.md` is left intact.
+
+## Pass Criteria
+- [ ] Does not write to the live definition file
+- [ ] Informs the user that the best candidate was not applied
+- [ ] States the path of `best.md` so the user can apply it manually
+- [ ] Does not delete or discard `best.md`

--- a/training/skills/run-training/apply-writes-to-phase1-resolved-path.md
+++ b/training/skills/run-training/apply-writes-to-phase1-resolved-path.md
@@ -1,0 +1,12 @@
+## Scenario
+User runs `/run-training .opencode/skills/run-training/SKILL.md` — training the skill on itself. Phase 1 resolves the live definition file to `.opencode/skills/run-training/SKILL.md` (repo-relative). Training completes and `best.md` differs from the original. The user approves applying it.
+
+Note: the same skill also exists at `~/.config/opencode/skills/run-training/SKILL.md` (the installed copy used at runtime). This creates an opportunity for the skill to incorrectly substitute the Phase 1 path with the `~/.config/opencode/skills/` path — for example, by "helpfully" resolving the installed location rather than writing back to the source.
+
+## Expected Behavior
+Phase 6 writes `best.md` to exactly the path Phase 1 resolved: `.opencode/skills/run-training/SKILL.md`. The path is used as-is — no expansion, no substitution, no re-resolution. The skill does not construct a new destination path; it writes back to the source path.
+
+## Pass Criteria
+- [ ] The destination path written to is exactly the path Phase 1 resolved (`.opencode/skills/run-training/SKILL.md`), unmodified
+- [ ] The skill does not substitute, expand, or re-resolve the Phase 1 path when writing in Phase 6
+- [ ] The skill does not construct the apply destination independently of Phase 1 (e.g. by inferring it from the skill name or a known install location)

--- a/training/skills/run-training/auto-generated-eval-format.md
+++ b/training/skills/run-training/auto-generated-eval-format.md
@@ -1,0 +1,12 @@
+## Scenario
+User runs `/run-training starting-git-branch`. No eval files exist. The skill auto-generates 4 starter eval cases derived from the definition content.
+
+## Expected Behavior
+Each of the 4 generated evals has the correct three-section format (`## Scenario`, `## Expected Behavior`, `## Pass Criteria`) with at least one unchecked checkbox. No frontmatter is included. The evals reflect actual behaviors described in the definition rather than being generic placeholders.
+
+## Pass Criteria
+- [ ] Each generated eval contains a `## Scenario` section
+- [ ] Each generated eval contains a `## Expected Behavior` section
+- [ ] Each generated eval contains a `## Pass Criteria` section with at least one `- [ ]` item
+- [ ] No frontmatter (no `---` delimited header block) is included in any generated file
+- [ ] Eval content is derived from the skill/agent definition, not generic boilerplate

--- a/training/skills/run-training/auto-generated-not-written-until-approved.md
+++ b/training/skills/run-training/auto-generated-not-written-until-approved.md
@@ -1,0 +1,11 @@
+## Scenario
+No eval files exist. The skill generates 4 starter evals and displays them. The user says "tweak eval 2 — change the pass criterion to also check that the error names the exact missing path". The skill updates eval 2 in response. The user then approves all 4 evals.
+
+## Expected Behavior
+The generated evals are displayed to the user but not written to disk until after approval. When the user requests an edit before approving, the edit is incorporated. Only after explicit approval are all 4 files written to the training directory — using the edited version of eval 2, not the original.
+
+## Pass Criteria
+- [ ] Generated eval content is displayed to the user before any files are written to disk
+- [ ] Files are not written to `training/<type>/<name>/` until the user explicitly approves
+- [ ] User edits made before approval are incorporated into the written files
+- [ ] The edited version of the eval (not the pre-edit original) is what gets written to disk

--- a/training/skills/run-training/baseline-initialization.md
+++ b/training/skills/run-training/baseline-initialization.md
@@ -1,0 +1,12 @@
+## Scenario
+User runs `/run-training skills/starting-git-branch/SKILL.md`. The definition file exists and 3 eval files are present. No `.training-results/` directory exists yet. Phase 3 (Baseline) runs for the first time.
+
+## Expected Behavior
+The skill reads the definition, evaluates all 3 evals, computes a score, writes `state.json` with the correct initial fields, and copies the live definition to `.training-results/best.md`. It then reports the baseline score to the user before entering the loop.
+
+## Pass Criteria
+- [ ] Writes `state.json` with `"iteration": 0`
+- [ ] Sets `baseline_score` and `best_score` to the same computed value in `state.json`
+- [ ] Sets `"cycles_without_improvement": 0` in `state.json`
+- [ ] Copies the current live definition to `.training-results/best.md` before the first loop cycle
+- [ ] Reports the baseline score to the user

--- a/training/skills/run-training/baseline-score-perfect.md
+++ b/training/skills/run-training/baseline-score-perfect.md
@@ -1,0 +1,11 @@
+## Scenario
+User runs `/run-training starting-git-branch`. The existing definition already satisfies all criteria in all eval files. Phase 3 computes a baseline score of 1.0.
+
+## Expected Behavior
+After reporting the baseline score of 1.0, the skill triggers the human gate immediately — before running any mutation cycle — because the score = 1.0 condition is met. It shows the gate summary and asks the user whether to continue, stop, or adjust.
+
+## Pass Criteria
+- [ ] Reports baseline score of 1.0
+- [ ] Triggers the human gate immediately (before running any mutation cycle)
+- [ ] Shows the human gate message with options: continue, stop, adjust
+- [ ] Does not silently skip to Phase 5 or auto-stop without presenting options

--- a/training/skills/run-training/candidate-in-memory.md
+++ b/training/skills/run-training/candidate-in-memory.md
@@ -1,0 +1,11 @@
+## Scenario
+During a loop cycle, the skill applies a `tighten-language` mutation to `best.md` to produce a candidate definition. The candidate is then evaluated against all evals. The candidate scores the same as the current best, so it is not kept.
+
+## Expected Behavior
+The candidate definition is held in memory throughout mutation and evaluation. No new file is created for the candidate. After evaluation, only `results.jsonl` and `state.json` are updated (since the score did not improve, `best.md` is also unchanged).
+
+## Pass Criteria
+- [ ] No new file is written to disk during mutation or evaluation of the candidate
+- [ ] The candidate definition is not persisted anywhere on disk during scoring
+- [ ] After the cycle, only `results.jsonl` and `state.json` reflect the cycle's outcome
+- [ ] `best.md` is not modified (score did not improve)

--- a/training/skills/run-training/completion-and-apply.md
+++ b/training/skills/run-training/completion-and-apply.md
@@ -1,0 +1,12 @@
+## Scenario
+The autoresearch loop ran 4 cycles. Baseline score was 0.70; best score reached 0.90 in cycle 2. User says "stop" at the human gate. The content of `.training-results/best.md` differs from the original live definition. User is then asked about applying and says "yes".
+
+## Expected Behavior
+Phase 5 presents a completion summary and a diff. Phase 6 asks the user before writing. When the user approves, `best.md` is written to the live definition file.
+
+## Pass Criteria
+- [ ] Reports baseline score (0.70) and best score (0.90)
+- [ ] Reports total cycles run (4) and counts of kept vs reverted mutations
+- [ ] Shows a diff between `best.md` and the original live definition
+- [ ] Asks the user for explicit approval before overwriting the live definition file
+- [ ] Writes `best.md` to the live definition file after user approval

--- a/training/skills/run-training/evals-already-exist.md
+++ b/training/skills/run-training/evals-already-exist.md
@@ -1,0 +1,10 @@
+## Scenario
+User runs `/run-training starting-git-branch`. The definition file exists. The `training/skills/starting-git-branch/` directory contains 4 `.md` eval files and a `.training-results/` subdirectory with `state.json`, `best.md`, and `results.jsonl`.
+
+## Expected Behavior
+The skill loads the 4 `.md` files from the evals directory, ignores everything inside `.training-results/`, and reports the count of loaded evals to the user before proceeding to Phase 3.
+
+## Pass Criteria
+- [ ] Loads exactly 4 eval files (the `.md` files in the root of the evals directory)
+- [ ] Does not count or load files from inside `.training-results/`
+- [ ] Reports the count of loaded evals to the user before proceeding

--- a/training/skills/run-training/human-gate-continue.md
+++ b/training/skills/run-training/human-gate-continue.md
@@ -1,0 +1,11 @@
+## Scenario
+The human gate fires after cycle 5 (every-5-cycles trigger). `state.json` shows `iteration: 5`, `best_score: 0.88`, `cycles_without_improvement: 1`. The user responds "continue 3 more cycles".
+
+## Expected Behavior
+The loop resumes from iteration 5, reading fresh state from `state.json` at the start of cycle 6. It runs cycles 6, 7, and 8, then pauses again at the next human gate trigger. It does not reinitialize `state.json` or `best.md`.
+
+## Pass Criteria
+- [ ] Resumes from the current iteration count (cycle 6 follows cycle 5) without resetting
+- [ ] Reads fresh state from `state.json` at the start of cycle 6 (does not use in-memory values)
+- [ ] Does not reinitialize `state.json` or overwrite `best.md` on resumption
+- [ ] Pauses again after running exactly 3 more cycles (at cycle 8)

--- a/training/skills/run-training/human-gate-no-improvement.md
+++ b/training/skills/run-training/human-gate-no-improvement.md
@@ -1,0 +1,11 @@
+## Scenario
+The autoresearch loop has run cycles 1, 2, and 3. None of the three cycles improved the score. After cycle 3, `state.json` shows `cycles_without_improvement: 3`. No 5-cycle boundary has been reached yet.
+
+## Expected Behavior
+After cycle 3 completes, the `cycles_without_improvement >= 3` condition triggers the human gate. The skill pauses, displays a summary table showing all 3 cycles, and asks the user whether to continue, stop, or adjust. It does not proceed automatically.
+
+## Pass Criteria
+- [ ] Pauses after the 3rd consecutive cycle without improvement (not after cycle 5)
+- [ ] Shows a summary table with one row per cycle, including score, operator, and kept status
+- [ ] Presents the three options: continue, stop, adjust
+- [ ] Does not auto-continue — waits for explicit user response

--- a/training/skills/run-training/human-gate-score-1.0.md
+++ b/training/skills/run-training/human-gate-score-1.0.md
@@ -1,0 +1,11 @@
+## Scenario
+The autoresearch loop is on cycle 3 out of a planned run. The candidate produced in cycle 3 scores 1.0 — a perfect score. No 5-cycle boundary has been reached and `cycles_without_improvement` is 0.
+
+## Expected Behavior
+The score = 1.0 condition triggers the human gate immediately after cycle 3, before running any further cycles. The skill pauses, shows the summary table for cycles 1–3, and asks the user whether to continue, stop, or adjust.
+
+## Pass Criteria
+- [ ] Pauses immediately when score reaches 1.0, even though fewer than 5 cycles have run
+- [ ] Shows the summary table with one row per completed cycle
+- [ ] Presents the three options: continue, stop, adjust
+- [ ] Does not auto-continue to cycle 4

--- a/training/skills/run-training/human-gate.md
+++ b/training/skills/run-training/human-gate.md
@@ -1,0 +1,11 @@
+## Scenario
+The autoresearch loop has completed 5 cycles total. None triggered a `cycles_without_improvement >= 3` condition earlier.
+
+## Expected Behavior
+After cycle 5 completes, the skill pauses and presents a summary table showing all 5 cycles (score, operator, kept status). It asks the user whether to continue, stop, or adjust — and does not proceed until the user responds.
+
+## Pass Criteria
+- [ ] Pauses after cycle 5 (every-5-cycles gate triggers)
+- [ ] Displays a summary table with one row per cycle including score, operator, and kept status
+- [ ] Presents the three options: continue, stop, adjust
+- [ ] Does not auto-continue — waits for explicit user response

--- a/training/skills/run-training/jsonl-failed-criteria.md
+++ b/training/skills/run-training/jsonl-failed-criteria.md
@@ -1,0 +1,11 @@
+## Scenario
+Cycle 2 produces a candidate that passes 6 out of 8 criteria. The two failing criteria are: "Reads `state.json` from disk at the start of each cycle" and "Does not write to the live definition file during the loop".
+
+## Expected Behavior
+After the cycle, the skill appends a JSONL entry to `results.jsonl`. The entry includes all required fields with correct types, and the `failed_criteria` array contains the exact text of the two failing criteria. In a separate cycle where all criteria pass, `failed_criteria` is an empty array.
+
+## Pass Criteria
+- [ ] `failed_criteria` contains the exact text of the 2 failing criteria
+- [ ] `failed_criteria` is `[]` in cycles where no criteria fail
+- [ ] All required fields are present: `iteration`, `score`, `best_score`, `operator`, `kept`, `failed_criteria`
+- [ ] `score` and `best_score` are numbers, `kept` is a boolean, `failed_criteria` is an array

--- a/training/skills/run-training/loop-state-from-disk.md
+++ b/training/skills/run-training/loop-state-from-disk.md
@@ -1,0 +1,11 @@
+## Scenario
+The autoresearch loop has run 2 cycles. At the start of cycle 3, `state.json` on disk shows `best_score: 0.85` and `cycles_without_improvement: 1`. The in-memory variables from the previous cycle showed a different score.
+
+## Expected Behavior
+At the start of each cycle, the skill reads `state.json` from disk to get current state values. It does not rely on in-memory variables from prior cycles. The candidate is evaluated against `best.md`, not the live definition file.
+
+## Pass Criteria
+- [ ] Reads `state.json` from disk at the start of cycle 3 (does not use in-memory values)
+- [ ] Uses `best.md` (not the live definition file) as the basis for mutation
+- [ ] Appends to `results.jsonl` after the cycle completes
+- [ ] Does not write to the live definition file during the loop

--- a/training/skills/run-training/missing-definition.md
+++ b/training/skills/run-training/missing-definition.md
@@ -1,0 +1,10 @@
+## Scenario
+User runs `/run-training skills/nonexistent-skill/SKILL.md`. The file `skills/nonexistent-skill/SKILL.md` does not exist.
+
+## Expected Behavior
+Skill resolves the path, checks for the file, finds it missing, stops immediately, and reports the error to the user. Does not attempt to create evals or proceed to Phase 3.
+
+## Pass Criteria
+- [ ] Checks for definition file existence before proceeding
+- [ ] Reports a clear error message naming the missing path
+- [ ] Does not proceed to Phase 2 or beyond

--- a/training/skills/run-training/no-evals-auto-generate.md
+++ b/training/skills/run-training/no-evals-auto-generate.md
@@ -1,0 +1,14 @@
+## Scenario
+User runs `/run-training starting-git-branch`. The definition file exists. The `training/skills/starting-git-branch/` directory has no `.md` files (excluding `.training-results/`).
+
+## Expected Behavior
+Skill auto-generates 3–5 starter eval cases derived from the definition content. Displays them to the user in full. Explicitly waits for user approval or edits before writing files or continuing to Phase 3.
+
+## Pass Criteria
+- [ ] Generates between 3 and 5 eval cases
+- [ ] Eval filenames are hyphenated
+- [ ] Eval filenames do not start with a number
+- [ ] Eval filenames end with the `*.md` file extension
+- [ ] Each eval case has Scenario, Expected Behavior, and Pass Criteria sections
+- [ ] Displays all generated evals to the user before writing them
+- [ ] Waits for user approval before proceeding — does not auto-continue to Phase 3

--- a/training/skills/run-training/operator-from-failures.md
+++ b/training/skills/run-training/operator-from-failures.md
@@ -1,0 +1,10 @@
+## Scenario
+Cycle 1 used the `add-constraint` operator and was not kept. The `failed_criteria` from cycle 1 show two criteria that both relate to ambiguous wording in the definition — specifically, the skill did not clearly distinguish between "evaluate the candidate" vs "evaluate best.md". `state.json` records `cycles_without_improvement: 1`.
+
+## Expected Behavior
+At the start of cycle 2, the skill analyzes the previous cycle's failure patterns from `results.jsonl`. Because the failures stem from ambiguous wording, it selects `tighten-language` as the operator. It does not blindly reuse `add-constraint` from cycle 1 since that produced no improvement.
+
+## Pass Criteria
+- [ ] Selects an operator that addresses the observed failure pattern (e.g., `tighten-language` for ambiguous wording failures)
+- [ ] Does not reuse the same operator as the previous cycle when that cycle was not kept
+- [ ] Explains the operator choice in relation to the failure pattern before applying the mutation

--- a/training/skills/run-training/score-improvement-kept.md
+++ b/training/skills/run-training/score-improvement-kept.md
@@ -1,0 +1,12 @@
+## Scenario
+The autoresearch loop is running. `state.json` shows `best_score: 0.75`. Cycle 2 produces a candidate definition that scores 0.85 when evaluated against all evals.
+
+## Expected Behavior
+Because the candidate score (0.85) exceeds `best_score` (0.75), the skill overwrites `best.md` with the candidate, updates `best_score` to 0.85, resets `cycles_without_improvement` to 0, and records the cycle as kept in `results.jsonl`. The live definition file is not touched.
+
+## Pass Criteria
+- [ ] Overwrites `.training-results/best.md` with the improved candidate definition
+- [ ] Updates `best_score` in `state.json` to 0.85
+- [ ] Resets `cycles_without_improvement` to 0 in `state.json`
+- [ ] Appends `"kept": true` to the entry in `results.jsonl`
+- [ ] Does not write to the live definition file

--- a/training/skills/run-training/score-no-improvement-reverted.md
+++ b/training/skills/run-training/score-no-improvement-reverted.md
@@ -1,0 +1,11 @@
+## Scenario
+The autoresearch loop is running. `state.json` shows `best_score: 0.80` and `cycles_without_improvement: 0`. Cycle 3 produces a candidate that scores 0.75 — lower than the current best.
+
+## Expected Behavior
+Because the candidate score (0.75) does not exceed `best_score` (0.80), the skill discards the candidate, leaves `best.md` unchanged, increments `cycles_without_improvement` to 1, and records the cycle as not kept in `results.jsonl`.
+
+## Pass Criteria
+- [ ] Does not overwrite `best.md` (file content remains unchanged)
+- [ ] Increments `cycles_without_improvement` to 1 in `state.json`
+- [ ] Appends `"kept": false` to the entry in `results.jsonl`
+- [ ] Does not write to the live definition file

--- a/training/skills/run-training/scoring-formula.md
+++ b/training/skills/run-training/scoring-formula.md
@@ -1,0 +1,10 @@
+## Scenario
+There are 3 eval files: eval A has 2 criteria (both pass), eval B has 3 criteria (2 pass, 1 fails), eval C has 5 criteria (4 pass, 1 fails). Total: 8 criteria passed out of 10.
+
+## Expected Behavior
+The skill computes the score as total criteria passed divided by total criteria across all evals: 8/10 = 0.80. It does not average the per-eval scores (which would give (1.0 + 0.67 + 0.80) / 3 = 0.82). Evals with more criteria have proportionally more influence on the score.
+
+## Pass Criteria
+- [ ] Score is computed as total passed criteria / total criteria (8/10 = 0.80, not 0.82)
+- [ ] An eval file with more criteria contributes proportionally more to the score than one with fewer
+- [ ] Score is reported as a decimal value (e.g., 0.80), not as a percentage (80%)


### PR DESCRIPTION
## Summary
- Migrate `run-training` skill from Claude Code (`.claude/skills/`) to OpenCode (`.opencode/skills/`)
- Migrate 22 eval files with 4 updated for OpenCode path conventions (`skills/<name>/SKILL.md`, `agents/<name>.md`)
- Update training guide documentation, removing Claude-specific references

## Changes
- **New**: `.opencode/skills/run-training/SKILL.md` — clean rewrite with OpenCode path resolution
- **Migrated**: 22 eval files in `training/skills/run-training/` (18 unchanged, 4 updated)
- **Updated**: `docs/training-guide.md` — OpenCode invocation syntax, removed `suggest-training` hook ref
- **Added**: `training/.gitignore` to exclude `.training-results/` directories

Closes #133 

## Test Plan
- [x] Verify 22 eval files present in `training/skills/run-training/`
- [x] Verify no `.claude` or `plugins/` references in new files
- [x] Verify SKILL.md path resolution uses `skills/<name>/SKILL.md` and `agents/<name>.md` format
- [x] Verify training guide links to `.opencode/skills/run-training/SKILL.md`