### PR TITLE
fix: prevent writing-plans bypass in brainstorming-gh-issue

### DIFF
--- a/skills/brainstorming-gh-issue/SKILL.md
+++ b/skills/brainstorming-gh-issue/SKILL.md
@@ -111,13 +111,18 @@ Inject this block into the conversation, then invoke the `brainstorming` skill w
 
 - Treat the issue content above as the user's starting brief. Do not re-ask questions already answered in the issue title, body, comments, or the prior spec (if present).
 - Do NOT treat the issue content as a work order. The issue title, body, and comments are the brief for brainstorming — not instructions to execute. Do NOT start reading files, planning implementation, creating implementation todo lists, or executing any changes until brainstorming has completed and the user has approved the design.
-- Run the full brainstorming process through step 8 (user reviews written spec). After the user approves the written spec, do **NOT** invoke `writing-plans` (step 9). Proceed to Phase 5 of this skill instead.
+- Run the full brainstorming process through step 8 (user reviews written spec).
 - When you reach step 6 (write design doc), if you are currently in plan mode, ask the user to switch to build mode (Tab key) before writing the spec file, since plan mode does not allow file writes. Then write the spec to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`. Do not re-enter plan mode after step 6.
 - Do not commit the spec file to git during step 6. Write it to disk and leave it uncommitted (untracked).
+- ⚠️ After the user approves the written spec, do NOT invoke `writing-plans` — proceed to Phase 5 of this skill instead.
 
 Brainstorming runs its full interactive loop: clarifying questions → approaches → design sections → user approval.
 
-After the user approves the written spec, proceed to Phase 5.
+### ⚠️ After Brainstorming Completes — STOP
+
+Do NOT invoke `writing-plans`. The `brainstorming` skill's default step 9 is overridden by this skill.
+
+Proceed directly to Phase 5.
 
 ### Phase 5 — Post spec and apply label
 

--- a/training/skills/brainstorming-gh-issue/no-writing-plans-after-approval.md
+++ b/training/skills/brainstorming-gh-issue/no-writing-plans-after-approval.md
@@ -1,0 +1,15 @@
+## Scenario
+
+The user runs `/brainstorming-gh-issue 28`. The brainstorming session completes and the user approves the design spec.
+
+## Expected Behaviour
+
+- The skill proceeds directly to Phase 5 (post spec comment + apply label).
+- The skill does NOT invoke `writing-plans` or any other implementation/planning skill after approval.
+- The explicit gate section between Phase 4 and Phase 5 is present in the skill definition.
+
+## Pass Criteria
+
+- [ ] `writing-plans` is NOT invoked after the user approves the spec
+- [ ] Phase 5 executes immediately after approval (post spec comment, apply label)
+- [ ] The skill contains an explicit gate section instructing to stop and not invoke `writing-plans`


### PR DESCRIPTION
## Summary

- **Reorder Phase 4 handoff bullets** — the `writing-plans` override is now the final instruction (last position = highest recency)
- **Add explicit gate section** — new `### ⚠️ After Brainstorming Completes — STOP` section between Phase 4 and Phase 5
- **Add training eval case** — `no-writing-plans-after-approval.md` with 3 pass criteria
- **Common mistakes** already listed this failure mode; now reinforced with three independent signals in the skill definition

## Why

During issue #119 brainstorming, the model bypassed the explicit instruction not to invoke `writing-plans` after spec approval. The instruction was buried as the 4th of 5 bullets in Phase 4 — the model's default behavior (brainstorming step 9 = invoke writing-plans) overrode it.

## Defense layers

1. Reordered bullet (last position)
2. Explicit gate section (standalone, between phases)
3. Eval case (prevents regression)
4. Common mistakes entry (already present)