### PR TITLE
Migrate init-plus to OpenCode as repo-setup skill

### DIFF
--- a/.opencode/skills/agent-skill-crafter/SKILL.md
+++ b/.opencode/skills/agent-skill-crafter/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: agent-skill-crafter
 description: Creates high-quality OpenCode skills and agents through guided workflows, pattern analysis, and automatic handoff to run-training for iterative improvement.
-user-invocable: true
 ---
 
 # Agent-Skill-Crafter: Create Skills and Agents
@@ -79,7 +78,6 @@ Produce a SKILL.md or agent.md following:
 - [ ] Description is 1-1024 characters and specific enough for the agent to choose correctly
 - [ ] Correct path conventions per doc standards
 - [ ] Agent has appropriate `mode`, `permission` fields
-- [ ] Skill has `user-invocable` field if applicable
 - [ ] Content follows clear, actionable instruction style
 
 ### Phase 5: Review Loop

--- a/.opencode/skills/repo-setup/SKILL.md
+++ b/.opencode/skills/repo-setup/SKILL.md
@@ -1,0 +1,383 @@
+---
+name: repo-setup
+description: Interactive repo setup wizard. Scans repo for missing infrastructure files and offers to create AGENTS.md, recommend plugins, set up triage workflows, issue templates, Dependabot, and a /verify skill.
+---
+
+# Repo Setup: Interactive Setup Wizard
+
+## Overview
+
+Presents a 6-step numbered menu; user selects which steps to run. Each step creates or overwrites repo infrastructure files with confirmation prompts. Steps always execute in ascending order (1→6).
+
+| Step | Outcome |
+|------|---------|
+| 1 | Generates AGENTS.md by delegating to the platform's built-in `/init` command (never writes directly) |
+| 2 | Recommends installing the superpowers plugin (non-blocking) |
+| 3 | Creates .github/workflows/triaging-gh-issue.yml — a CI workflow that auto-triages new issues |
+| 4 | Creates 3 issue templates: feature request, bug report, and config.yml (blank issues disabled) |
+| 5 | Delegates entirely to configuring-dependabot |
+| 6 | Bootstraps a local `verify` skill at `.opencode/skills/verify/SKILL.md` with user-provided verification commands |
+
+**Usage:** `/repo-setup`
+
+Step 5 (Dependabot) is delegated entirely to `configuring-dependabot`.
+
+## When to Use
+
+**Use when:**
+- Setting up a new repository with standard project infrastructure
+- Adding one or more standard files to an existing repository
+
+**Do not use when:**
+- You only want to configure Dependabot — run `/configuring-dependabot` directly instead
+
+## Prerequisites
+
+- For Step 3: a GitHub App and project board must be configured — see [docs/github-setup.md](https://github.com/HeadlessTarry/Token-Effort/blob/main/docs/github-setup.md)
+- For Step 5: the `configuring-dependabot` skill must be installed
+
+## Process
+
+### Phase 1 — Repo scan & menu presentation
+
+Scan the repository using Glob to detect which artefacts already exist:
+
+| Step | File/path to check |
+|------|-------------------|
+| 1. AGENTS.md | `AGENTS.md` (repo root) |
+| 2. Superpowers plugin | Cannot be verified locally — always `[not verified]` |
+| 3. Triage workflow | `.github/workflows/triaging-gh-issue.yml` |
+| 4. Issue templates | `.github/ISSUE_TEMPLATE/` (any file in this directory) |
+| 5. Dependabot | `.github/dependabot.yml` |
+| 6. Bootstrap `/verify` skill | `.opencode/skills/verify/SKILL.md` |
+
+Present the following menu, substituting the correct status annotation for each item:
+
+```
+Select which setup steps to run (e.g. "1 3 5" or "all"):
+
+1. Generate AGENTS.md                          [<status>]
+2. Recommend superpowers plugin                [not verified]
+3. Create auto-triage GitHub Actions workflow  [<status>]
+4. Create GitHub issue templates               [<status>]
+5. Configure Dependabot                        [<status>]
+6. Bootstrap `/verify` skill                   [<status>]
+```
+
+Status annotations:
+- `[not present]` — file/dir does not exist
+- `[exists — will overwrite]` — file/dir exists and would be replaced
+- `[not verified]` — superpowers plugin only
+
+Wait for the user to reply with space-separated numbers (e.g. `1 3`) or `all`. Parse the reply into a sorted list of step numbers. Always execute steps in ascending order 1→6 regardless of input order. If the input is invalid (e.g. numbers outside 1-6, non-numeric text), print "Please enter valid step numbers (1-6) or 'all'" and re-prompt.
+
+### Phase 2 — Execute selected steps
+
+---
+**Step 1 — AGENTS.md**
+
+If `AGENTS.md` exists:
+
+> "`AGENTS.md` already exists. Overwrite? [yes/no]"
+
+Wait for confirmation. If the user says no, note "AGENTS.md: skipped (overwrite declined)" in the summary and move on.
+
+Invoke `/init` via the Skill tool (`skill: "init"`) to generate `AGENTS.md`. Do not write `AGENTS.md` directly or use a hardcoded template — `/init` analyses the project and produces contextual content. If `/init` is not available, inform the user and note "AGENTS.md: skipped (/init not available)" in the summary.
+
+---
+**Step 2 — Superpowers plugin**
+
+Print:
+
+> **Strongly recommended: Install the `superpowers` plugin.**
+>
+> The `superpowers` plugin adds powerful skills for planning, TDD, debugging, and code review.
+> Install from the plugin marketplace, or visit: https://github.com/obra/superpowers
+
+Ask:
+
+> "Have you installed the superpowers plugin (or do you already have it)? [yes/no/skip]"
+
+If the user says yes, note "Superpowers plugin: confirmed installed" in the summary.
+If the user says no or skips, note "Superpowers plugin: not installed (recommended)" in the summary. Do not block.
+
+---
+**Step 3 — Auto-triage GitHub Actions workflow**
+
+Print:
+
+> "Step 3 requires a GitHub App and project board. See [docs/github-setup.md](https://github.com/HeadlessTarry/Token-Effort/blob/main/docs/github-setup.md) for setup instructions."
+
+Ask:
+
+> "Is everything in [docs/github-setup.md](https://github.com/HeadlessTarry/Token-Effort/blob/main/docs/github-setup.md) configured? [yes/no/skip]"
+
+If the user says no or skips, print:
+
+> "Complete the setup in [docs/github-setup.md](https://github.com/HeadlessTarry/Token-Effort/blob/main/docs/github-setup.md), then re-run `/repo-setup` and select Step 3 to continue."
+
+Note "Triage workflow: skipped (prerequisites not met)" in the summary and continue to Step 4.
+
+If `.github/workflows/triaging-gh-issue.yml` exists:
+
+> "`.github/workflows/triaging-gh-issue.yml` already exists. Overwrite? [yes/no]"
+
+Wait for confirmation. If the user says no, note "Triage workflow: skipped (overwrite declined)" in the summary and continue.
+
+Create directory `.github/workflows/` if it does not exist.
+
+Write `.github/workflows/triaging-gh-issue.yml` with the following OpenCode-format workflow content:
+
+```yaml
+name: Triage GitHub Issue
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to triage'
+        required: true
+        type: number
+
+jobs:
+  triage:
+    name: Triage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run skill
+        uses: anomalyco/opencode/github@main
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: opencode-go/qwen3.6-plus
+          prompt: |
+            Use the triaging-gh-issue skill to triage issue ${{ github.event.issue.number || inputs.issue_number }}.
+```
+
+---
+**Step 4 — GitHub issue templates**
+
+Check if any of the following files exist:
+- `.github/ISSUE_TEMPLATE/01-feature_request.md`
+- `.github/ISSUE_TEMPLATE/02-bug_report.md`
+- `.github/ISSUE_TEMPLATE/config.yml`
+
+If any exist:
+
+> "One or more issue template files already exist. Overwrite all? [yes/no]"
+
+Wait for confirmation. If the user says no, note "Issue templates: skipped (overwrite declined)" in the summary and continue.
+
+Create directory `.github/ISSUE_TEMPLATE/` if it does not exist.
+
+Write `.github/ISSUE_TEMPLATE/01-feature_request.md`:
+
+```markdown
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+assignees: ''
+
+---
+
+## Is your feature request related to a problem? Please describe.
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.
+```
+
+Write `.github/ISSUE_TEMPLATE/02-bug_report.md`:
+
+```markdown
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+assignees: ''
+
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Additional context
+
+Add any other context about the problem here.
+```
+
+Write `.github/ISSUE_TEMPLATE/config.yml`:
+
+```yaml
+---
+blank_issues_enabled: false
+```
+
+---
+**Step 5 — Dependabot config**
+
+Invoke: `configuring-dependabot`
+
+Do not perform any Dependabot logic directly. The sub-skill handles all scanning, overwrite detection, and file writing.
+
+---
+**Step 6 — Bootstrap `/verify` skill**
+
+Check if `.opencode/skills/verify/SKILL.md` already exists.
+
+If it exists:
+
+> "`/verify` skill already exists — skipping."
+
+Note "`/verify`: skipped (already exists)" in the summary and continue.
+
+Otherwise, ask:
+
+> "What commands should be run to verify this project is working correctly? List them in the order they should run."
+
+If the user says they don't know yet or wants to skip:
+
+> "`/verify` not configured — run `/repo-setup` again when you're ready to set this up."
+
+Note "`/verify`: skipped (no commands provided)" in the summary and continue.
+
+Otherwise, confirm the list back to the user:
+
+> "I'll configure `/verify` with these commands in order:
+> 1. `<command 1>`
+> 2. `<command 2>`
+> ...
+> Is that correct? [yes/no]"
+
+Wait for confirmation. If the user says no, re-ask for the command list.
+
+Create directory `.opencode/skills/verify/` if it does not exist.
+
+Write `.opencode/skills/verify/SKILL.md`, substituting the confirmed commands for `<command N>`:
+
+```markdown
+---
+name: verify
+description: Use when asked to verify changes, run all checks, confirm everything
+  is working, run tests, or check nothing is broken before committing
+---
+
+# Verify
+
+Run all project checks to confirm changes are working correctly.
+
+## Commands
+
+Run each of the following commands. Report the result of each (pass/fail and any output).
+If any command fails, stop and report the failure. Do not run any remaining commands.
+
+1. `<command 1>`
+2. `<command 2>`
+<!-- repeat for each additional command -->
+```
+
+Note "`/verify`: created" in the summary.
+
+### Phase 3 — Completion summary
+
+Print a summary of all selected steps:
+
+```
+✅ Done. Here's what was set up:
+- AGENTS.md: created
+- Superpowers plugin: confirmed installed
+- Triage workflow: created
+- Issue templates: created
+- Dependabot: delegated to /configuring-dependabot
+- /verify: created
+```
+
+Adjust each line to reflect the actual outcome (e.g. "created", "skipped (overwrite declined)", "skipped (prerequisites not met)", "not installed (recommended)"). Include only the steps the user selected — omit unselected steps from the summary entirely.
+
+No git commit is made. The user decides what to commit.
+
+## Common Mistakes
+
+- **Skipping overwrite checks** — always warn and ask before writing any file that already exists.
+- **Executing steps not selected by the user** — only run the steps the user chose.
+- **Executing steps out of order** — always run in order 1→6 regardless of user input order.
+- **Blocking on Step 3 prerequisites** — if the user says prerequisites are not set up, note it in the summary and continue. Do not halt.
+- **Blocking on Step 2 "no"** — if the user says the superpowers plugin is not installed, note it and continue. Do not halt.
+- **Performing Dependabot logic directly in Step 5** — always delegate to `configuring-dependabot`. Do not scan ecosystems or write `dependabot.yml` yourself.
+- **Writing `AGENTS.md` directly in Step 1** — always delegate to `/init` via the Skill tool. Do not write the file directly or use a hardcoded template.
+- **Omitting skipped steps from the summary** — every selected step must appear in the summary, even if skipped or declined.
+- **Writing `/verify` when it already exists** — always check for `.opencode/skills/verify/SKILL.md` first. If it exists, skip with the log message and do not overwrite.
+- **Not confirming commands before writing** — always echo the command list back to the user and wait for a yes confirmation before writing `.opencode/skills/verify/SKILL.md`.
+- **Writing the file when the user skips** — if the user says they don't know or wants to skip, do not generate any file. Log the "not configured" message and move on.
+- **Making a git commit after setup** — no git commit is made. The user decides what to commit.
+
+## Eval
+
+- [ ] Scanned repo for all six artefacts before presenting menu
+- [ ] Presented menu with correct status annotations (`[not present]`, `[exists — will overwrite]`, `[not verified]`)
+- [ ] Waited for user selection before executing any steps
+- [ ] Parsed "all" as selecting all six steps
+- [ ] Executed only the selected steps
+- [ ] Executed steps in order 1→6 regardless of input order
+- [ ] Step 1: Warned and confirmed before overwriting `AGENTS.md`
+- [ ] Step 1: Invoked `/init` via Skill tool to generate `AGENTS.md`
+- [ ] Step 1: Did not write `AGENTS.md` directly or use a hardcoded template
+- [ ] Step 2: Printed superpowers install recommendation with GitHub URL
+- [ ] Step 2: Asked if installed; did not block on "no" or "skip"
+- [ ] Step 3: Referenced docs/github-setup.md for prerequisites
+- [ ] Step 3: Asked if prerequisites set up; skipped workflow on "no"/"skip"
+- [ ] Step 3: Warned and confirmed before overwriting existing workflow file
+- [ ] Step 4: Warned and confirmed before overwriting any existing template files
+- [ ] Step 4: Wrote all three template files with correct content
+- [ ] Step 5: Delegated to `configuring-dependabot` via Skill tool
+- [ ] Step 5: Did not perform any Dependabot logic directly
+- [ ] Step 6: Checked for existing `.opencode/skills/verify/SKILL.md` before proceeding
+- [ ] Step 6: Skipped with log message when `/verify` already exists; did not overwrite
+- [ ] Step 6: Asked for verification commands when skill not present
+- [ ] Step 6: Confirmed command list with user before writing
+- [ ] Step 6: Did not write file when user skipped; logged "not configured" message
+- [ ] Step 6: Wrote `.opencode/skills/verify/SKILL.md` with correct frontmatter, description, ordered command list, and stop-on-failure instruction
+- [ ] Step 6: Noted outcome in completion summary
+- [ ] Printed completion summary covering every selected step with accurate outcomes
+- [ ] Made no git commit

--- a/.opencode/skills/run-training/SKILL.md
+++ b/.opencode/skills/run-training/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: run-training
 description: Use when the user wants to iteratively improve a skill or agent definition through automated evaluation cycles against committed test cases.
-user-invocable: true
 ---
 
 # Training: Iterative Skill/Agent Improvement

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -1,0 +1,211 @@
+# ⚙️ GitHub Setup Guide
+
+This guide covers the GitHub infrastructure required to use the skills and agents. The full workflow — triaging issues, brainstorming specs, building features, and cutting releases — depends on this foundation. It does **not** cover platform configuration, plugin installation, or the release pipeline — only the GitHub-side setup.
+
+**Audience:** Project maintainers, contributors, and external users who want to use these skills on their own GitHub repositories.
+
+---
+
+## ✅ Prerequisites Checklist
+
+Use this checklist to see what you still need to set up. Each item links to the detailed section below.
+
+- [ ] [GitHub organisation](#1-github-organisation) (or personal account — see [Personal Account Alternative](#personal-account-alternative))
+- [ ] ["Project Manager" GitHub App](#2-project-manager-github-app) created and installed on the repository
+- [ ] [GitHub Project board](#3-github-project-board) with Status field: `New` → `Brainstorming` → `Building` → `Done`
+- [ ] [Project board linked to the repository](#3-github-project-board) (Settings → Linked repositories)
+- [ ] [Issue labels](#4-issue-labels): `enhancement`, `bug`, `documentation`, `duplicate`, `pending-review`
+- [ ] [Repository secret](#5-repository-secrets--variables): `PROJECT_MANAGER_PRIVATE_KEY`
+- [ ] [Repository secret](#5-repository-secrets--variables): `OPENCODE_API_KEY`
+- [ ] [Repository variable](#5-repository-secrets--variables): `PROJECT_MANAGER_CLIENT_ID`
+- [ ] [Triage workflow](#6-triage-workflow) added to `.github/workflows/`
+
+---
+
+## 🏢 1. GitHub Organisation
+
+A GitHub organisation is required because GitHub Apps cannot be granted access to Projects under a personal account — this is a platform limitation.
+
+> **On a personal account?** Skip this section and see [Personal Account Alternative](#personal-account-alternative) instead.
+
+**Steps:**
+
+1. Follow [GitHub's documentation to create an organisation](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch).
+2. Transfer or create your repository under the organisation.
+
+---
+
+## 🤖 2. Project Manager GitHub App
+
+The Project Manager GitHub App is used by the triage workflow to authenticate with elevated permissions for both issue management and project board operations — permissions that the default `GITHUB_TOKEN` does not provide.
+
+> **On a personal account?** Skip this section and see [Personal Account Alternative](#personal-account-alternative) instead.
+
+**Steps:**
+
+1. Go to your organisation's **Settings** → **Developer settings** → **GitHub Apps** → **New GitHub App**.
+2. Fill in the required fields:
+   - **GitHub App name:** `Project Manager` (or any name you prefer)
+   - **Homepage URL:** your repository URL (e.g. `https://github.com/your-org/your-repo`)
+3. Under **Webhook**, uncheck **Active** — the webhook is not needed.
+4. Set the following permissions:
+   - **Repository permissions → Issues:** Read & Write
+   - **Organization permissions → Projects:** Read & Write
+5. Click **Create GitHub App**.
+6. On the app's settings page, note the **Client ID** (labelled `Client ID`, formatted as `Iv1.xxxxxxxxxx`) — you will need it later. This is distinct from the numeric **App ID** shown just above it; the workflow requires the Client ID.
+7. Scroll down to **Private keys** and click **Generate a private key**. A `.pem` file will download — keep it safe.
+8. Go to the app's **Install App** tab and install it on your target repository.
+
+---
+
+## 📋 3. GitHub Project Board
+
+The project board tracks issue status through the workflow lifecycle. The triage skill reads and writes the `Status` field to move issues between columns automatically.
+
+**Steps:**
+
+1. Navigate to your organisation's **Projects** tab → **New project**.
+2. Choose **Board** or **Table** layout (either works).
+3. Link the project to your repository:
+   - Open the project → **Settings** → **Linked repositories** → add your repo.
+4. Add a single-select field named exactly **`Status`** with options in this exact order:
+    - `New`
+    - `Brainstorming`
+    - `Building`
+    - `Done`
+
+> **Important:** The field must be named exactly `Status` (case-sensitive). The `move-issue-status` skill searches for this field by name.
+
+---
+
+## 🏷️ 4. Issue Labels
+
+These labels are used by the triage skill to classify issues by type. Run the following commands against your repository to create them:
+
+```bash
+# Check what labels already exist to avoid duplicates with GitHub defaults
+gh label list
+
+# Create the required labels
+gh label create "enhancement"    --color "#a2eeef" --description "New feature or request"
+gh label create "bug"            --color "#d73a4a" --description "Something isn't working"
+gh label create "documentation"  --color "#0075ca" --description "Improvements or additions to documentation"
+gh label create "duplicate"      --color "#cfd3d7" --description "This issue or pull request already exists"
+gh label create "pending-review" --color "#FEF2C0" --description "Spec posted, awaiting human approval"
+```
+
+Alternatively, you can create labels via **Settings** → **Labels** in the GitHub UI.
+
+> **Note:** GitHub creates several default labels (e.g. `bug`, `documentation`, `duplicate`, `enhancement`) when a repository is initialised. Run `gh label list` first and skip `gh label create` for any that already exist.
+
+---
+
+## 🔐 5. Repository Secrets & Variables
+
+The triage workflow uses one repository variable and two secrets. Add them under **Settings** → **Secrets and variables** → **Actions**.
+
+### Variables (Variables tab)
+
+| Variable | Value |
+|----------|-------|
+| `PROJECT_MANAGER_CLIENT_ID` | The **Client ID** from the GitHub App General settings page (step 2.6 above — the `Iv1.` prefixed string, not the numeric App ID) |
+
+### Secrets (Secrets tab)
+
+| Secret | Value |
+|--------|-------|
+| `PROJECT_MANAGER_PRIVATE_KEY` | Full contents of the `.pem` file downloaded in step 2.7 above |
+| `OPENCODE_API_KEY` | Your API key — generated during setup. See the platform documentation for your version. |
+
+> **On a personal account?** Replace the `PROJECT_MANAGER_CLIENT_ID` variable and `PROJECT_MANAGER_PRIVATE_KEY` secret with a single `GITHUB_PAT` secret — see [Personal Account Alternative](#personal-account-alternative).
+
+---
+
+## ⚙️ 6. Triage Workflow
+
+The triage workflow runs automatically every Monday at 4am UTC and can also be triggered manually. It authenticates as the Project Manager GitHub App, then invokes the `triaging-gh-issue` skill, which labels issues by type, detects duplicates, and advances issue statuses on the project board.
+
+> **On a personal account?** See [Personal Account Alternative](#personal-account-alternative) for the workflow changes needed.
+
+**Steps:**
+
+1. Download the workflow file into your repository:
+
+   ```bash
+   mkdir -p .github/workflows && curl -sSL https://raw.githubusercontent.com/HeadlessTarry/Token-Effort/main/.github/workflows/triaging-gh-issue.yml -o .github/workflows/triaging-gh-issue.yml
+   ```
+
+   Alternatively, view the [latest version on main](https://github.com/HeadlessTarry/Token-Effort/blob/main/.github/workflows/triaging-gh-issue.yml) and copy its contents manually into `.github/workflows/triaging-gh-issue.yml` in your repository.
+
+2. Leave the `plugin_marketplaces` and `plugins` inputs as-is — they point to the plugin source and should not be changed.
+
+---
+
+## 👤 Personal Account Alternative
+
+GitHub Apps require organisation-level permissions to access GitHub Projects. Personal accounts do not support this permission scope. If you are working under a personal account, use a Personal Access Token (PAT) instead.
+
+**Why the limitation exists:** GitHub App permissions for Projects are only available at the organisation level. Personal accounts have no equivalent permission scope.
+
+**Alternative setup:**
+
+1. Create a classic Personal Access Token with the `repo` and `project` scopes:
+   - Go to **Settings** → **Developer settings** → **Personal access tokens** → **Tokens (classic)** → **Generate new token**.
+   - Select scopes: `repo` (full control) and `project` (full control of projects).
+2. Store the PAT as a repository secret named `GITHUB_PAT` (under **Settings** → **Secrets and variables** → **Actions** → **Secrets**).
+3. Update the triage workflow — remove the `🔑 Authenticate as Project Manager` step (the `actions/create-github-app-token` block) and change the `github_token` input:
+
+   Remove this block entirely:
+
+   ```yaml
+         - name: 🔑 Authenticate as Project Manager
+           id: project-manager-token
+           uses: actions/create-github-app-token@v3
+           with:
+             client-id: ${{ vars.PROJECT_MANAGER_CLIENT_ID }}
+             private-key: ${{ secrets.PROJECT_MANAGER_PRIVATE_KEY }}
+             owner: ${{ github.repository_owner }}
+   ```
+
+   Then change the `github_token` input in the `Run skill` step:
+
+   ```yaml
+   # Change from:
+   github_token: ${{ steps.project-manager-token.outputs.token }}
+
+   # To:
+   github_token: ${{ secrets.GITHUB_PAT }}
+   ```
+
+> **Security note:** Classic PATs are broadly scoped compared to GitHub Apps. Rotate them regularly and use the minimum required scopes.
+
+---
+
+## ✔️ Verification
+
+After completing all steps above, run the following to confirm everything is in place:
+
+```bash
+# Confirm all 5 required labels exist
+gh label list
+
+# Confirm the project board is visible
+gh project list --owner <your-org>
+
+# Trigger the triage workflow manually (run from inside a cloned copy of your repo,
+# or pass --repo explicitly)
+gh workflow run triaging-gh-issue.yml --repo <your-org>/<your-repo>
+```
+
+After triggering the workflow, open the **Actions** tab in your repository and select the **Triage GitHub Issue** run. The workflow will post a markdown summary to the step summary once it completes — a successful run will show a brief activity report.
+
+---
+
+## 🚫 Out of Scope
+
+This guide does not cover:
+
+- Installing the plugin
+- Configuring the platform itself (model settings, permissions)
+- Setting up the Release Manager GitHub App
+- Creating issue templates — not required for triage to run, but recommended. This repository's templates at [`.github/ISSUE_TEMPLATE/`](https://github.com/HeadlessTarry/Token-Effort/tree/main/.github/ISSUE_TEMPLATE) can be used as a starting point.

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -10,55 +10,16 @@ This guide covers the GitHub infrastructure required to use the skills and agent
 
 Use this checklist to see what you still need to set up. Each item links to the detailed section below.
 
-- [ ] [GitHub organisation](#1-github-organisation) (or personal account — see [Personal Account Alternative](#personal-account-alternative))
-- [ ] ["Project Manager" GitHub App](#2-project-manager-github-app) created and installed on the repository
+- [ ] [GitHub organisation](#1-github-organisation) (or personal account)
 - [ ] [GitHub Project board](#3-github-project-board) with Status field: `New` → `Brainstorming` → `Building` → `Done`
 - [ ] [Project board linked to the repository](#3-github-project-board) (Settings → Linked repositories)
 - [ ] [Issue labels](#4-issue-labels): `enhancement`, `bug`, `documentation`, `duplicate`, `pending-review`
-- [ ] [Repository secret](#5-repository-secrets--variables): `PROJECT_MANAGER_PRIVATE_KEY`
 - [ ] [Repository secret](#5-repository-secrets--variables): `OPENCODE_API_KEY`
-- [ ] [Repository variable](#5-repository-secrets--variables): `PROJECT_MANAGER_CLIENT_ID`
 - [ ] [Triage workflow](#6-triage-workflow) added to `.github/workflows/`
 
 ---
 
-## 🏢 1. GitHub Organisation
-
-A GitHub organisation is required because GitHub Apps cannot be granted access to Projects under a personal account — this is a platform limitation.
-
-> **On a personal account?** Skip this section and see [Personal Account Alternative](#personal-account-alternative) instead.
-
-**Steps:**
-
-1. Follow [GitHub's documentation to create an organisation](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch).
-2. Transfer or create your repository under the organisation.
-
----
-
-## 🤖 2. Project Manager GitHub App
-
-The Project Manager GitHub App is used by the triage workflow to authenticate with elevated permissions for both issue management and project board operations — permissions that the default `GITHUB_TOKEN` does not provide.
-
-> **On a personal account?** Skip this section and see [Personal Account Alternative](#personal-account-alternative) instead.
-
-**Steps:**
-
-1. Go to your organisation's **Settings** → **Developer settings** → **GitHub Apps** → **New GitHub App**.
-2. Fill in the required fields:
-   - **GitHub App name:** `Project Manager` (or any name you prefer)
-   - **Homepage URL:** your repository URL (e.g. `https://github.com/your-org/your-repo`)
-3. Under **Webhook**, uncheck **Active** — the webhook is not needed.
-4. Set the following permissions:
-   - **Repository permissions → Issues:** Read & Write
-   - **Organization permissions → Projects:** Read & Write
-5. Click **Create GitHub App**.
-6. On the app's settings page, note the **Client ID** (labelled `Client ID`, formatted as `Iv1.xxxxxxxxxx`) — you will need it later. This is distinct from the numeric **App ID** shown just above it; the workflow requires the Client ID.
-7. Scroll down to **Private keys** and click **Generate a private key**. A `.pem` file will download — keep it safe.
-8. Go to the app's **Install App** tab and install it on your target repository.
-
----
-
-## 📋 3. GitHub Project Board
+## 📋 2. GitHub Project Board
 
 The project board tracks issue status through the workflow lifecycle. The triage skill reads and writes the `Status` field to move issues between columns automatically.
 
@@ -78,7 +39,7 @@ The project board tracks issue status through the workflow lifecycle. The triage
 
 ---
 
-## 🏷️ 4. Issue Labels
+## 🏷️ 3. Issue Labels
 
 These labels are used by the triage skill to classify issues by type. Run the following commands against your repository to create them:
 
@@ -100,84 +61,29 @@ Alternatively, you can create labels via **Settings** → **Labels** in the GitH
 
 ---
 
-## 🔐 5. Repository Secrets & Variables
+## 🔐 4. Repository Secrets & Variables
 
-The triage workflow uses one repository variable and two secrets. Add them under **Settings** → **Secrets and variables** → **Actions**.
-
-### Variables (Variables tab)
-
-| Variable | Value |
-|----------|-------|
-| `PROJECT_MANAGER_CLIENT_ID` | The **Client ID** from the GitHub App General settings page (step 2.6 above — the `Iv1.` prefixed string, not the numeric App ID) |
+The triage workflow uses one repository secret. Add it under **Settings** → **Secrets and variables** → **Actions** → **Secrets**.
 
 ### Secrets (Secrets tab)
 
 | Secret | Value |
 |--------|-------|
-| `PROJECT_MANAGER_PRIVATE_KEY` | Full contents of the `.pem` file downloaded in step 2.7 above |
-| `OPENCODE_API_KEY` | Your API key — generated during setup. See the platform documentation for your version. |
+| `OPENCODE_API_KEY` | Your API key — generated during setup. See your OpenCode documentation for key generation. |
 
-> **On a personal account?** Replace the `PROJECT_MANAGER_CLIENT_ID` variable and `PROJECT_MANAGER_PRIVATE_KEY` secret with a single `GITHUB_PAT` secret — see [Personal Account Alternative](#personal-account-alternative).
+> **Note:** The workflow uses `${{ secrets.GITHUB_TOKEN }}` automatically — no additional token configuration is needed.
 
 ---
 
-## ⚙️ 6. Triage Workflow
+## ⚙️ 5. Triage Workflow
 
-The triage workflow runs automatically every Monday at 4am UTC and can also be triggered manually. It authenticates as the Project Manager GitHub App, then invokes the `triaging-gh-issue` skill, which labels issues by type, detects duplicates, and advances issue statuses on the project board.
-
-> **On a personal account?** See [Personal Account Alternative](#personal-account-alternative) for the workflow changes needed.
+The triage workflow runs when a new issue is opened and can also be triggered manually. It invokes the `triaging-gh-issue` skill, which labels issues by type, detects duplicates, and advances issue statuses on the project board.
 
 **Steps:**
 
-1. Download the workflow file into your repository:
+1. Add the workflow file to `.github/workflows/triaging-gh-issue.yml` in your repository. The workflow uses the `anomalyco/opencode/github` action with `OPENCODE_API_KEY` and `GITHUB_TOKEN` secrets.
 
-   ```bash
-   mkdir -p .github/workflows && curl -sSL https://raw.githubusercontent.com/HeadlessTarry/Token-Effort/main/.github/workflows/triaging-gh-issue.yml -o .github/workflows/triaging-gh-issue.yml
-   ```
-
-   Alternatively, view the [latest version on main](https://github.com/HeadlessTarry/Token-Effort/blob/main/.github/workflows/triaging-gh-issue.yml) and copy its contents manually into `.github/workflows/triaging-gh-issue.yml` in your repository.
-
-2. Leave the `plugin_marketplaces` and `plugins` inputs as-is — they point to the plugin source and should not be changed.
-
----
-
-## 👤 Personal Account Alternative
-
-GitHub Apps require organisation-level permissions to access GitHub Projects. Personal accounts do not support this permission scope. If you are working under a personal account, use a Personal Access Token (PAT) instead.
-
-**Why the limitation exists:** GitHub App permissions for Projects are only available at the organisation level. Personal accounts have no equivalent permission scope.
-
-**Alternative setup:**
-
-1. Create a classic Personal Access Token with the `repo` and `project` scopes:
-   - Go to **Settings** → **Developer settings** → **Personal access tokens** → **Tokens (classic)** → **Generate new token**.
-   - Select scopes: `repo` (full control) and `project` (full control of projects).
-2. Store the PAT as a repository secret named `GITHUB_PAT` (under **Settings** → **Secrets and variables** → **Actions** → **Secrets**).
-3. Update the triage workflow — remove the `🔑 Authenticate as Project Manager` step (the `actions/create-github-app-token` block) and change the `github_token` input:
-
-   Remove this block entirely:
-
-   ```yaml
-         - name: 🔑 Authenticate as Project Manager
-           id: project-manager-token
-           uses: actions/create-github-app-token@v3
-           with:
-             client-id: ${{ vars.PROJECT_MANAGER_CLIENT_ID }}
-             private-key: ${{ secrets.PROJECT_MANAGER_PRIVATE_KEY }}
-             owner: ${{ github.repository_owner }}
-   ```
-
-   Then change the `github_token` input in the `Run skill` step:
-
-   ```yaml
-   # Change from:
-   github_token: ${{ steps.project-manager-token.outputs.token }}
-
-   # To:
-   github_token: ${{ secrets.GITHUB_PAT }}
-   ```
-
-> **Security note:** Classic PATs are broadly scoped compared to GitHub Apps. Rotate them regularly and use the minimum required scopes.
+2. The workflow triggers automatically on new issues (`issues: types: [opened]`) and supports manual triggering via `workflow_dispatch` with an `issue_number` input.
 
 ---
 
@@ -196,8 +102,6 @@ gh project list --owner <your-org>
 # or pass --repo explicitly)
 gh workflow run triaging-gh-issue.yml --repo <your-org>/<your-repo>
 ```
-
-After triggering the workflow, open the **Actions** tab in your repository and select the **Triage GitHub Issue** run. The workflow will post a markdown summary to the step summary once it completes — a successful run will show a brief activity report.
 
 ---
 

--- a/training/repo-setup/agents-md-exists-overwrite-confirmed.md
+++ b/training/repo-setup/agents-md-exists-overwrite-confirmed.md
@@ -1,0 +1,14 @@
+## Scenario
+AGENTS.md already exists in the repository root with custom content. The user
+selects "1" and then says "yes" when asked to overwrite.
+
+## Expected Behavior
+Step 1 detects the existing file, warns the user, receives "yes", then invokes
+`/init` via the Skill tool to regenerate AGENTS.md.
+
+## Pass Criteria
+- [ ] Warned that AGENTS.md already exists
+- [ ] Asked for overwrite confirmation before proceeding
+- [ ] Invoked the Skill tool with skill: "init" after receiving "yes"
+- [ ] Did NOT write a hardcoded template directly
+- [ ] Completion summary reports "AGENTS.md: created" or equivalent (not "skipped")

--- a/training/repo-setup/agents-md-exists-overwrite-declined.md
+++ b/training/repo-setup/agents-md-exists-overwrite-declined.md
@@ -1,0 +1,15 @@
+## Scenario
+AGENTS.md already exists in the repository root with custom content. The user
+selects "1" and then says "no" when asked to overwrite.
+
+## Expected Behavior
+Step 1 detects the existing file, warns the user, and asks "Overwrite? [yes/no]".
+The user says no. The skill skips Step 1 without invoking /init.
+
+## Pass Criteria
+- [ ] Warned that AGENTS.md already exists
+- [ ] Asked for overwrite confirmation before proceeding
+- [ ] Did NOT invoke /init (Skill tool not called for "init")
+- [ ] Did NOT write AGENTS.md (original content preserved)
+- [ ] Noted "skipped (overwrite declined)" or equivalent in the completion summary
+- [ ] Did NOT halt the skill entirely after the decline

--- a/training/repo-setup/agents-md-no-hardcoded-template.md
+++ b/training/repo-setup/agents-md-no-hardcoded-template.md
@@ -1,0 +1,12 @@
+## Scenario
+AGENTS.md does not exist. The user selects "1". The skill runs Step 1.
+
+## Expected Behavior
+Step 1 must NOT write a hardcoded template. Instead it delegates to `/init`
+via the Skill tool. The resulting AGENTS.md content is produced by `/init`,
+not by init-plus itself.
+
+## Pass Criteria
+- [ ] Skill tool was called with skill: "init" (or "/init")
+- [ ] init-plus did NOT use the Write tool to write AGENTS.md directly
+- [ ] init-plus did NOT emit the literal text "# 🏗️ Architecture" as part of a Write call

--- a/training/repo-setup/agents-md-no-hardcoded-template.md
+++ b/training/repo-setup/agents-md-no-hardcoded-template.md
@@ -4,9 +4,9 @@ AGENTS.md does not exist. The user selects "1". The skill runs Step 1.
 ## Expected Behavior
 Step 1 must NOT write a hardcoded template. Instead it delegates to `/init`
 via the Skill tool. The resulting AGENTS.md content is produced by `/init`,
-not by init-plus itself.
+not by repo-setup itself.
 
 ## Pass Criteria
 - [ ] Skill tool was called with skill: "init" (or "/init")
-- [ ] init-plus did NOT use the Write tool to write AGENTS.md directly
-- [ ] init-plus did NOT emit the literal text "# 🏗️ Architecture" as part of a Write call
+- [ ] repo-setup did NOT use the Write tool to write AGENTS.md directly
+- [ ] repo-setup did NOT emit the literal text "# 🏗️ Architecture" as part of a Write call

--- a/training/repo-setup/agents-md-not-present-invokes-init.md
+++ b/training/repo-setup/agents-md-not-present-invokes-init.md
@@ -1,0 +1,12 @@
+## Scenario
+AGENTS.md does not exist in the repository root. The user selects "1".
+
+## Expected Behavior
+Step 1 detects no existing AGENTS.md (skips the overwrite warning) and invokes
+the built-in `/init` command via the Skill tool to generate AGENTS.md.
+
+## Pass Criteria
+- [ ] Did NOT show an overwrite warning (file didn't exist)
+- [ ] Invoked the Skill tool with skill: "init" (or equivalent)
+- [ ] Did NOT write a hardcoded template directly
+- [ ] Completion summary reports "AGENTS.md: created"

--- a/training/repo-setup/all-keyword-selects-all-six.md
+++ b/training/repo-setup/all-keyword-selects-all-six.md
@@ -1,0 +1,12 @@
+## Scenario
+A clean repository. The user types "all" (rather than "1 2 3 4 5 6") when prompted.
+
+## Expected Behavior
+The skill treats "all" as equivalent to selecting all six steps. All six steps execute
+in order 1→6.
+
+## Pass Criteria
+- [ ] Parsed "all" as selecting steps 1, 2, 3, 4, 5, and 6
+- [ ] Executed all six steps
+- [ ] Steps executed in order 1 → 2 → 3 → 4 → 5 → 6
+- [ ] Completion summary covers all six steps

--- a/training/repo-setup/all-steps-clean-repo.md
+++ b/training/repo-setup/all-steps-clean-repo.md
@@ -1,0 +1,22 @@
+## Scenario
+A clean repository with no AGENTS.md, no .github/workflows/triaging-gh-issue.yml, no
+.github/ISSUE_TEMPLATE/ directory, no .github/dependabot.yml, and no
+.opencode/skills/verify/SKILL.md. The user selects "all". The user confirms prerequisites
+for Step 3, says yes to superpowers, and provides verification commands for Step 6.
+
+## Expected Behavior
+The skill scans the repo, shows the menu with all items as [not present] except Step 2
+which shows [not verified]. It runs all six steps in order 1→6. Each step creates its
+respective file(s). Step 5 delegates to configuring-dependabot.
+
+## Pass Criteria
+- [ ] Presented menu with all six steps before executing anything
+- [ ] Step 1 created AGENTS.md
+- [ ] Step 2 printed the superpowers recommendation and asked if installed
+- [ ] Step 3 asked about prerequisites before writing the workflow
+- [ ] Step 3 wrote .github/workflows/triaging-gh-issue.yml
+- [ ] Step 4 wrote all three issue template files
+- [ ] Step 5 invoked configuring-dependabot via Skill tool
+- [ ] Step 6 asked for verification commands and wrote .opencode/skills/verify/SKILL.md
+- [ ] Printed a completion summary listing all six steps
+- [ ] Steps executed in order 1 → 2 → 3 → 4 → 5 → 6

--- a/training/repo-setup/menu-shown-before-any-execution.md
+++ b/training/repo-setup/menu-shown-before-any-execution.md
@@ -1,0 +1,13 @@
+## Scenario
+A clean repository. The user will select "all".
+
+## Expected Behavior
+The skill presents the full numbered menu and waits for the user's selection BEFORE
+executing any step. It does not begin writing files, asking step-specific questions,
+or invoking sub-skills until the user has replied with their selection.
+
+## Pass Criteria
+- [ ] Presented the complete 6-item menu before executing any step
+- [ ] Waited for user input before starting any step
+- [ ] Did NOT write any files before receiving the selection
+- [ ] Did NOT ask any step-specific questions (e.g. superpowers install) before the menu selection

--- a/training/repo-setup/no-git-commit-made.md
+++ b/training/repo-setup/no-git-commit-made.md
@@ -1,0 +1,12 @@
+## Scenario
+The user selects "all" and all five steps complete successfully in a clean repository.
+
+## Expected Behavior
+After all steps complete, the skill prints the summary and stops. It does NOT run any
+git add, git commit, or git push commands. The user is left to decide what to commit.
+
+## Pass Criteria
+- [ ] Did NOT run git add
+- [ ] Did NOT run git commit
+- [ ] Did NOT run git push
+- [ ] Completion summary does not mention committing or pushing

--- a/training/repo-setup/repo-scan-annotations-mixed.md
+++ b/training/repo-setup/repo-scan-annotations-mixed.md
@@ -1,0 +1,22 @@
+## Scenario
+A repository where AGENTS.md exists and .github/workflows/triaging-gh-issue.yml exists,
+but .github/ISSUE_TEMPLATE/ does not exist, .github/dependabot.yml does not exist, and
+.opencode/skills/verify/SKILL.md does not exist.
+
+## Expected Behavior
+The menu is presented with accurate status annotations reflecting what was found:
+- Step 1 shows [exists — will overwrite]
+- Step 2 shows [not verified]
+- Step 3 shows [exists — will overwrite]
+- Step 4 shows [not present]
+- Step 5 shows [not present]
+- Step 6 shows [not present]
+
+## Pass Criteria
+- [ ] Step 1 shows [exists — will overwrite] (AGENTS.md found)
+- [ ] Step 2 shows [not verified] (superpowers cannot be verified locally)
+- [ ] Step 3 shows [exists — will overwrite] (triaging-gh-issue.yml found)
+- [ ] Step 4 shows [not present] (no ISSUE_TEMPLATE dir)
+- [ ] Step 5 shows [not present] (no dependabot.yml)
+- [ ] Step 6 shows [not present] (no .opencode/skills/verify/SKILL.md)
+- [ ] Menu is shown before asking for user selection

--- a/training/repo-setup/single-step-selection.md
+++ b/training/repo-setup/single-step-selection.md
@@ -1,0 +1,13 @@
+## Scenario
+A clean repository. The user selects only "4" (issue templates).
+
+## Expected Behavior
+Only Step 4 runs. Steps 1, 2, 3, and 5 are not executed at all. The completion summary
+covers only Step 4.
+
+## Pass Criteria
+- [ ] Executed only Step 4
+- [ ] Did NOT execute Steps 1, 2, 3, 5, or 6
+- [ ] Step 4 created .github/ISSUE_TEMPLATE/ directory (did not exist in clean repo)
+- [ ] Step 4 wrote all three issue template files
+- [ ] Completion summary includes "Issue templates:" (or equivalent named entry) for Step 4 and no entries for Steps 1, 2, 3, 5, or 6

--- a/training/repo-setup/skipped-selected-steps-appear-in-summary.md
+++ b/training/repo-setup/skipped-selected-steps-appear-in-summary.md
@@ -1,0 +1,15 @@
+## Scenario
+The user selects "1 2 3". For Step 1 the user says "no" to overwrite (AGENTS.md exists).
+For Step 2 the user says "no" (superpowers not installed). For Step 3 the user says "no"
+to prerequisites.
+
+## Expected Behavior
+All three selected steps are skipped (for different reasons), but all three appear in the
+completion summary with their respective skip reasons. No steps are silently omitted.
+
+## Pass Criteria
+- [ ] Completion summary includes an entry for Step 1 noting it was skipped (overwrite declined)
+- [ ] Completion summary includes an entry for Step 2 noting superpowers not installed
+- [ ] Completion summary includes an entry for Step 3 noting prerequisites not met
+- [ ] No files were written (all three were skipped)
+- [ ] Skill completed cleanly without halting

--- a/training/repo-setup/step2-skip-response.md
+++ b/training/repo-setup/step2-skip-response.md
@@ -1,0 +1,13 @@
+## Scenario
+The user selects "2". When asked "Have you installed the superpowers plugin (or do you
+already have it)? [yes/no/skip]", the user replies "skip".
+
+## Expected Behavior
+"skip" is treated the same as "no" — the skill notes superpowers is not installed in the
+summary, does not block, and completes cleanly.
+
+## Pass Criteria
+- [ ] Treated "skip" as equivalent to "no" for the superpowers question
+- [ ] Noted "not installed (recommended)" or equivalent in the completion summary
+- [ ] Did NOT block or halt after "skip"
+- [ ] Skill completed cleanly

--- a/training/repo-setup/step3-prerequisites-not-met-skipped.md
+++ b/training/repo-setup/step3-prerequisites-not-met-skipped.md
@@ -1,0 +1,15 @@
+## Scenario
+The user selects "3". When asked "Is everything in docs/github-setup.md configured?",
+the user says "no".
+
+## Expected Behavior
+Step 3 references docs/github-setup.md, asks the prerequisite question, receives "no",
+notes "Triage workflow: skipped (prerequisites not met)" in the summary, and does NOT
+write the workflow file. The skill does not halt.
+
+## Pass Criteria
+- [ ] Referenced docs/github-setup.md in the prerequisite message
+- [ ] Asked the user if prerequisites are configured before attempting to write the file
+- [ ] Did NOT write .github/workflows/triaging-gh-issue.yml
+- [ ] Noted "skipped (prerequisites not met)" or equivalent in the completion summary
+- [ ] Did NOT halt or error — continued cleanly to the summary

--- a/training/repo-setup/step3-setup-link-is-github-url.md
+++ b/training/repo-setup/step3-setup-link-is-github-url.md
@@ -1,0 +1,16 @@
+## Scenario
+<!-- Covers: SKILL.md "Step 3 — Auto-triage GitHub Actions workflow" prerequisite block -->
+The user selects "3". The skill prints the Step 3 prerequisite message and asks if
+everything is configured.
+
+## Expected Behavior
+The prerequisite message and the follow-up skip message must reference
+`docs/github-setup.md` as a Markdown link pointing to
+`https://github.com/HeadlessTarry/Token-Effort/` — not as a bare local path or
+backtick-quoted filename. The specific version tag in the URL may vary across
+releases and is not checked.
+
+## Pass Criteria
+- [ ] The prerequisite message contains a Markdown link whose URL starts with `https://github.com/HeadlessTarry/Token-Effort/`
+- [ ] The prerequisite message does NOT present `docs/github-setup.md` as a bare backtick-quoted local path
+- [ ] The follow-up skip message (printed when the user says no/skip) also uses a GitHub URL link, not a bare path

--- a/training/repo-setup/step3-skip-response-skips-workflow.md
+++ b/training/repo-setup/step3-skip-response-skips-workflow.md
@@ -1,0 +1,13 @@
+## Scenario
+The user selects "3". When asked if prerequisites in docs/github-setup.md are configured,
+the user replies "skip" (rather than yes or no).
+
+## Expected Behavior
+"skip" is treated the same as "no" for the prerequisites question — the workflow is not
+written, it is noted in the summary, and the skill continues cleanly.
+
+## Pass Criteria
+- [ ] Treated "skip" as equivalent to "no" for the prerequisites question
+- [ ] Did NOT write .github/workflows/triaging-gh-issue.yml
+- [ ] Noted the skip in the completion summary
+- [ ] Skill continued and completed cleanly (did not halt or error)

--- a/training/repo-setup/step3-workflow-content-accuracy.md
+++ b/training/repo-setup/step3-workflow-content-accuracy.md
@@ -1,0 +1,25 @@
+## Scenario
+The user selects "3", confirms prerequisites, no existing workflow file. The skill writes
+.github/workflows/triaging-gh-issue.yml.
+
+## Expected Behavior
+The written workflow file must match the template defined in the skill exactly, including
+the correct action versions, trigger (issues.opened + workflow_dispatch with issue_number
+input), allowedTools list, and prompt text.
+
+## Pass Criteria
+- [ ] Workflow name is "Triage GitHub Issue"
+- [ ] Trigger is `on: issues: types: [opened]` (not a cron schedule)
+- [ ] `workflow_dispatch` has an `issue_number` input with `required: true` and `type: number`
+- [ ] Uses "anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa #v1"
+- [ ] Uses actions/create-github-app-token@v3
+- [ ] References vars.PROJECT_MANAGER_CLIENT_ID and secrets.PROJECT_MANAGER_PRIVATE_KEY
+- [ ] References secrets.CLAUDE_CODE_OAUTH_TOKEN
+- [ ] plugin_marketplaces includes HeadlessTarry/Token-Effort.git
+- [ ] Prompt instructs to use token-effort-workflow:triaging-gh-issue
+- [ ] Prompt passes the issue number: `#${{ github.event.issue.number || inputs.issue_number }}`
+- [ ] allowedTools includes Skill and required Bash permissions
+- [ ] allowedTools includes Bash(git branch --show-current)
+- [ ] allowedTools does NOT include Bash(gh issue list *)
+- [ ] claude_args includes --model sonnet
+- [ ] Prompt block includes the GITHUB_STEP_SUMMARY write pattern

--- a/training/repo-setup/step3-workflow-content-accuracy.md
+++ b/training/repo-setup/step3-workflow-content-accuracy.md
@@ -5,21 +5,15 @@ The user selects "3", confirms prerequisites, no existing workflow file. The ski
 ## Expected Behavior
 The written workflow file must match the template defined in the skill exactly, including
 the correct action versions, trigger (issues.opened + workflow_dispatch with issue_number
-input), allowedTools list, and prompt text.
+input), and prompt text.
 
 ## Pass Criteria
 - [ ] Workflow name is "Triage GitHub Issue"
 - [ ] Trigger is `on: issues: types: [opened]` (not a cron schedule)
 - [ ] `workflow_dispatch` has an `issue_number` input with `required: true` and `type: number`
-- [ ] Uses "anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa #v1"
-- [ ] Uses actions/create-github-app-token@v3
-- [ ] References vars.PROJECT_MANAGER_CLIENT_ID and secrets.PROJECT_MANAGER_PRIVATE_KEY
-- [ ] References secrets.CLAUDE_CODE_OAUTH_TOKEN
-- [ ] plugin_marketplaces includes HeadlessTarry/Token-Effort.git
-- [ ] Prompt instructs to use token-effort-workflow:triaging-gh-issue
-- [ ] Prompt passes the issue number: `#${{ github.event.issue.number || inputs.issue_number }}`
-- [ ] allowedTools includes Skill and required Bash permissions
-- [ ] allowedTools includes Bash(git branch --show-current)
-- [ ] allowedTools does NOT include Bash(gh issue list *)
-- [ ] claude_args includes --model sonnet
-- [ ] Prompt block includes the GITHUB_STEP_SUMMARY write pattern
+- [ ] Uses `anomalyco/opencode/github` action
+- [ ] Uses `secrets.GITHUB_TOKEN` for authentication
+- [ ] Uses `secrets.OPENCODE_API_KEY` env var
+- [ ] Model is `opencode-go/qwen3.6-plus`
+- [ ] Prompt instructs to use the triaging-gh-issue skill
+- [ ] Prompt passes the issue number: `${{ github.event.issue.number || inputs.issue_number }}`

--- a/training/repo-setup/step3-workflow-created-successfully.md
+++ b/training/repo-setup/step3-workflow-created-successfully.md
@@ -1,0 +1,17 @@
+## Scenario
+The user selects "3". No .github/workflows/triaging-gh-issue.yml exists. The user
+confirms prerequisites are set up.
+
+## Expected Behavior
+Step 3 asks about prerequisites, receives confirmation, skips the overwrite warning
+(file doesn't exist), creates the .github/workflows/ directory if needed, and writes
+the workflow file.
+
+## Pass Criteria
+- [ ] Asked about prerequisites and received confirmation before writing
+- [ ] Did NOT show an overwrite warning (file didn't exist)
+- [ ] Wrote .github/workflows/triaging-gh-issue.yml
+- [ ] Written workflow contains "anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa #v1"
+- [ ] Written workflow contains "actions/create-github-app-token@v3"
+- [ ] Written workflow contains "token-effort-workflow:triaging-gh-issue" in the prompt
+- [ ] Completion summary reports the workflow was created

--- a/training/repo-setup/step3-workflow-created-successfully.md
+++ b/training/repo-setup/step3-workflow-created-successfully.md
@@ -11,7 +11,6 @@ the workflow file.
 - [ ] Asked about prerequisites and received confirmation before writing
 - [ ] Did NOT show an overwrite warning (file didn't exist)
 - [ ] Wrote .github/workflows/triaging-gh-issue.yml
-- [ ] Written workflow contains "anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa #v1"
-- [ ] Written workflow contains "actions/create-github-app-token@v3"
-- [ ] Written workflow contains "token-effort-workflow:triaging-gh-issue" in the prompt
+- [ ] Written workflow contains "anomalyco/opencode/github"
+- [ ] Written workflow contains "triaging-gh-issue skill" in the prompt
 - [ ] Completion summary reports the workflow was created

--- a/training/repo-setup/step3-workflow-exists-overwrite-confirmed.md
+++ b/training/repo-setup/step3-workflow-exists-overwrite-confirmed.md
@@ -1,0 +1,16 @@
+## Scenario
+.github/workflows/triaging-gh-issue.yml already exists. The user selects "3", confirms
+prerequisites are set up, and says "yes" when asked about overwriting.
+
+## Expected Behavior
+Step 3 confirms prerequisites, detects the existing workflow file, warns the user, receives
+"yes", and re-writes the workflow file with the standard template content. The completion
+summary reports the workflow as created/overwritten (not skipped).
+
+## Pass Criteria
+- [ ] Detected the existing .github/workflows/triaging-gh-issue.yml
+- [ ] Warned that the file only exists before writing
+- [ ] Asked for overwrite confirmation
+- [ ] Wrote .github/workflows/triaging-gh-issue.yml after "yes"
+- [ ] Written workflow contains "anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa #v1"
+- [ ] Completion summary reports workflow as created or overwritten (not skipped)

--- a/training/repo-setup/step3-workflow-exists-overwrite-confirmed.md
+++ b/training/repo-setup/step3-workflow-exists-overwrite-confirmed.md
@@ -12,5 +12,5 @@ summary reports the workflow as created/overwritten (not skipped).
 - [ ] Warned that the file only exists before writing
 - [ ] Asked for overwrite confirmation
 - [ ] Wrote .github/workflows/triaging-gh-issue.yml after "yes"
-- [ ] Written workflow contains "anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa #v1"
+- [ ] Written workflow contains "anomalyco/opencode/github"
 - [ ] Completion summary reports workflow as created or overwritten (not skipped)

--- a/training/repo-setup/step3-workflow-exists-overwrite-declined.md
+++ b/training/repo-setup/step3-workflow-exists-overwrite-declined.md
@@ -1,0 +1,15 @@
+## Scenario
+.github/workflows/triaging-gh-issue.yml already exists. The user selects "3", confirms
+prerequisites, but says "no" when asked about overwriting.
+
+## Expected Behavior
+Step 3 confirms prerequisites, detects the existing workflow file, warns the user, receives
+"no", and skips writing. This is noted in the summary. The skill does not halt.
+
+## Pass Criteria
+- [ ] Detected the existing .github/workflows/triaging-gh-issue.yml
+- [ ] Warned that the file already exists before writing
+- [ ] Asked for overwrite confirmation
+- [ ] Did NOT overwrite the file after "no"
+- [ ] Noted "skipped (overwrite declined)" or equivalent in the completion summary
+- [ ] Did NOT halt the skill after the decline

--- a/training/repo-setup/step4-all-templates-created.md
+++ b/training/repo-setup/step4-all-templates-created.md
@@ -1,0 +1,14 @@
+## Scenario
+No .github/ISSUE_TEMPLATE/ directory exists. The user selects "4".
+
+## Expected Behavior
+Step 4 detects no existing template files, skips the overwrite warning, creates the
+.github/ISSUE_TEMPLATE/ directory, and writes all three template files.
+
+## Pass Criteria
+- [ ] Did NOT show an overwrite warning (no files existed)
+- [ ] Wrote .github/ISSUE_TEMPLATE/01-feature_request.md
+- [ ] Wrote .github/ISSUE_TEMPLATE/02-bug_report.md
+- [ ] Wrote .github/ISSUE_TEMPLATE/config.yml
+- [ ] config.yml contains "blank_issues_enabled: false"
+- [ ] Completion summary reports templates were created

--- a/training/repo-setup/step4-templates-exist-overwrite-confirmed.md
+++ b/training/repo-setup/step4-templates-exist-overwrite-confirmed.md
@@ -1,0 +1,14 @@
+## Scenario
+All three .github/ISSUE_TEMPLATE/ files already exist with custom content. The user selects
+"4" and says "yes" when asked about overwriting.
+
+## Expected Behavior
+Step 4 detects existing templates, warns, receives "yes", and overwrites all three files
+with the standard templates.
+
+## Pass Criteria
+- [ ] Detected existing template files
+- [ ] Warned that template files already exist
+- [ ] Overwrote all three files after "yes"
+- [ ] config.yml contains blank_issues_enabled: false
+- [ ] Completion summary reports templates as created/overwritten (not skipped)

--- a/training/repo-setup/step4-templates-exist-overwrite-declined.md
+++ b/training/repo-setup/step4-templates-exist-overwrite-declined.md
@@ -1,0 +1,16 @@
+## Scenario
+.github/ISSUE_TEMPLATE/01-feature_request.md already exists (but 02-bug_report.md and
+config.yml do not). The user selects "4" and says "no" when asked about overwriting.
+
+## Expected Behavior
+Step 4 detects the existing template file(s), presents a single consolidated warning and
+overwrite question covering all template files, receives "no", and skips writing all
+templates. This is noted in the summary. The skill does not halt.
+
+## Pass Criteria
+- [ ] Detected at least one existing template file
+- [ ] Warned that template file(s) already exist before writing
+- [ ] Asked a single overwrite question (not per-file)
+- [ ] Did NOT write any template files after "no"
+- [ ] Noted "skipped (overwrite declined)" or equivalent in the completion summary
+- [ ] Did NOT halt the skill after the decline

--- a/training/repo-setup/step5-delegates-to-configuring-dependabot.md
+++ b/training/repo-setup/step5-delegates-to-configuring-dependabot.md
@@ -1,0 +1,16 @@
+## Scenario
+The user selects "5". The repository has package.json and .github/workflows/ci.yml
+(but no dependabot.yml).
+
+## Expected Behavior
+Step 5 delegates entirely to configuring-dependabot via the Skill tool.
+The init-plus skill does NOT scan for ecosystems, does NOT check for existing dependabot
+files, and does NOT write dependabot.yml itself. All of that logic is handled by the
+sub-skill.
+
+## Pass Criteria
+- [ ] Invoked configuring-dependabot via the Skill tool
+- [ ] Did NOT perform any ecosystem scanning itself
+- [ ] Did NOT write .github/dependabot.yml directly
+- [ ] Did NOT check for existing .github/dependabot.yml or .github/dependabot.yaml itself
+- [ ] Completion summary notes that Dependabot was delegated to /configuring-dependabot

--- a/training/repo-setup/step5-delegates-to-configuring-dependabot.md
+++ b/training/repo-setup/step5-delegates-to-configuring-dependabot.md
@@ -4,7 +4,7 @@ The user selects "5". The repository has package.json and .github/workflows/ci.y
 
 ## Expected Behavior
 Step 5 delegates entirely to configuring-dependabot via the Skill tool.
-The init-plus skill does NOT scan for ecosystems, does NOT check for existing dependabot
+The repo-setup skill does NOT scan for ecosystems, does NOT check for existing dependabot
 files, and does NOT write dependabot.yml itself. All of that logic is handled by the
 sub-skill.
 

--- a/training/repo-setup/step6-confirmation-rejected-re-asks.md
+++ b/training/repo-setup/step6-confirmation-rejected-re-asks.md
@@ -1,0 +1,14 @@
+## Scenario
+`.opencode/skills/verify/SKILL.md` does NOT exist. The user selects "6", provides commands
+(`npm test`, `npm run build`), but says "no" to the echo confirmation. The user then
+provides a corrected list (`npm test`, `npm run build --strict`) and says "yes".
+
+## Expected Behavior
+Step 6 does NOT write the file after the first "no". It re-asks for the command list,
+receives the corrected list, echoes it back again, receives "yes", then writes the file.
+
+## Pass Criteria
+- [ ] Did NOT write `.opencode/skills/verify/SKILL.md` after the first "no"
+- [ ] Re-asked for the command list after "no" (did not halt)
+- [ ] Echoed the corrected command list back for a second confirmation
+- [ ] Wrote `.opencode/skills/verify/SKILL.md` after the corrected "yes" confirmation

--- a/training/repo-setup/step6-correct-skill-file-content.md
+++ b/training/repo-setup/step6-correct-skill-file-content.md
@@ -1,0 +1,16 @@
+## Scenario
+`.opencode/skills/verify/SKILL.md` does NOT exist. The user selects "6", provides three
+commands (`npm test`, `npm run lint`, `npm run build`), and confirms "yes". The skill
+writes the file.
+
+## Expected Behavior
+The written `.opencode/skills/verify/SKILL.md` contains correct frontmatter, an appropriate
+description, the commands as a numbered ordered list, and an instruction to stop and
+report if any command fails.
+
+## Pass Criteria
+- [ ] Written file includes YAML frontmatter with `name: verify`
+- [ ] Written file includes `user-invocable: true` in frontmatter
+- [ ] Description field mentions verifying, running checks, or confirming changes work
+- [ ] Commands appear as a numbered ordered list (1. 2. 3.)
+- [ ] File includes instruction to stop and report failure if any command fails

--- a/training/repo-setup/step6-correct-skill-file-content.md
+++ b/training/repo-setup/step6-correct-skill-file-content.md
@@ -10,7 +10,6 @@ report if any command fails.
 
 ## Pass Criteria
 - [ ] Written file includes YAML frontmatter with `name: verify`
-- [ ] Written file includes `user-invocable: true` in frontmatter
 - [ ] Description field mentions verifying, running checks, or confirming changes work
 - [ ] Commands appear as a numbered ordered list (1. 2. 3.)
 - [ ] File includes instruction to stop and report failure if any command fails

--- a/training/repo-setup/step6-menu-annotation.md
+++ b/training/repo-setup/step6-menu-annotation.md
@@ -1,0 +1,13 @@
+## Scenario
+A repository where .opencode/skills/verify/SKILL.md already exists. The user invokes the
+skill (any step selection is fine — the test is about the menu scan only).
+
+## Expected Behavior
+The menu scan detects .opencode/skills/verify/SKILL.md and shows Step 6 as
+[exists — will overwrite]. If instead the file is absent, Step 6 shows [not present].
+Both annotation paths must be correct.
+
+## Pass Criteria
+- [ ] Scanned for .opencode/skills/verify/SKILL.md during the repo scan phase
+- [ ] Step 6 shows [exists — will overwrite] when .opencode/skills/verify/SKILL.md is present
+- [ ] Step 6 shows [not present] when .opencode/skills/verify/SKILL.md is absent

--- a/training/repo-setup/step6-user-skips-command-list.md
+++ b/training/repo-setup/step6-user-skips-command-list.md
@@ -1,0 +1,14 @@
+## Scenario
+`.opencode/skills/verify/SKILL.md` does NOT exist. The user selects "6". When asked for
+verification commands, the user responds "I don't know yet" (or equivalent skip intent).
+
+## Expected Behavior
+Step 6 asks for commands, receives a skip response, prints the "not configured" message,
+does NOT write any file, and notes the outcome in the summary. The skill does not halt.
+
+## Pass Criteria
+- [ ] Asked the user for verification commands
+- [ ] Did NOT write `.opencode/skills/verify/SKILL.md`
+- [ ] Printed "`/verify` not configured — run `/init-plus` again when you're ready" (or equivalent)
+- [ ] Noted "`/verify`: skipped (no commands provided)" (or equivalent) in the completion summary
+- [ ] Did NOT halt the skill after the skip

--- a/training/repo-setup/step6-user-skips-command-list.md
+++ b/training/repo-setup/step6-user-skips-command-list.md
@@ -9,6 +9,6 @@ does NOT write any file, and notes the outcome in the summary. The skill does no
 ## Pass Criteria
 - [ ] Asked the user for verification commands
 - [ ] Did NOT write `.opencode/skills/verify/SKILL.md`
-- [ ] Printed "`/verify` not configured — run `/init-plus` again when you're ready" (or equivalent)
+- [ ] Printed "`/verify` not configured — run `/repo-setup` again when you're ready" (or equivalent)
 - [ ] Noted "`/verify`: skipped (no commands provided)" (or equivalent) in the completion summary
 - [ ] Did NOT halt the skill after the skip

--- a/training/repo-setup/step6-verify-created-with-commands.md
+++ b/training/repo-setup/step6-verify-created-with-commands.md
@@ -1,0 +1,14 @@
+## Scenario
+`.opencode/skills/verify/SKILL.md` does NOT exist. The user selects "6", provides two
+commands (`npm test` and `npm run lint`), and says "yes" when the skill echoes the list
+back for confirmation.
+
+## Expected Behavior
+Step 6 asks for commands, echoes them back, receives confirmation, writes the skill file,
+and notes the outcome in the summary.
+
+## Pass Criteria
+- [ ] Asked the user for verification commands
+- [ ] Echoed the command list back to the user for confirmation before writing
+- [ ] Wrote `.opencode/skills/verify/SKILL.md` after the user confirmed
+- [ ] Noted "`/verify`: created" (or equivalent) in the completion summary

--- a/training/repo-setup/step6-verify-skill-already-exists.md
+++ b/training/repo-setup/step6-verify-skill-already-exists.md
@@ -1,0 +1,13 @@
+## Scenario
+`.opencode/skills/verify/SKILL.md` already exists in the repository. The user selects "6".
+
+## Expected Behavior
+Step 6 detects the existing file and skips creation entirely. It prints a skip message,
+does NOT ask for commands or overwrite the file, and notes the outcome in the summary.
+
+## Pass Criteria
+- [ ] Checked for `.opencode/skills/verify/SKILL.md` before doing anything else in Step 6
+- [ ] Printed "`/verify` skill already exists — skipping." (or equivalent)
+- [ ] Did NOT ask for verification commands
+- [ ] Did NOT write or overwrite `.opencode/skills/verify/SKILL.md`
+- [ ] Noted "`/verify`: skipped (already exists)" (or equivalent) in the completion summary

--- a/training/repo-setup/steps-run-in-order-regardless-of-input.md
+++ b/training/repo-setup/steps-run-in-order-regardless-of-input.md
@@ -1,0 +1,14 @@
+## Scenario
+A clean repository. The user types "5 2 1" (steps in reverse order) when prompted for
+their selection.
+
+## Expected Behavior
+The skill parses the selection and executes steps 1, 2, and 5 in ascending order (1 → 2 → 5),
+not in the order the user typed them. Steps 3 and 4 are not executed.
+
+## Pass Criteria
+- [ ] Parsed user input "5 2 1" into the set {1, 2, 5}
+- [ ] Executed Step 1 before Step 2
+- [ ] Executed Step 2 before Step 5
+- [ ] Did NOT execute Step 3 or Step 4
+- [ ] Completion summary includes only steps 1, 2, and 5

--- a/training/repo-setup/superpowers-always-not-verified.md
+++ b/training/repo-setup/superpowers-always-not-verified.md
@@ -1,0 +1,13 @@
+## Scenario
+A repository where the superpowers plugin is installed locally (e.g. a plugin config file
+exists at .claude/plugins/). The user selects "2".
+
+## Expected Behavior
+The skill always shows [not verified] for Step 2 in the menu — it does not attempt to
+detect the superpowers plugin from local files. The annotation is always [not verified].
+
+## Pass Criteria
+- [ ] Step 2 shows [not verified] in the menu regardless of any local plugin files
+- [ ] The skill did NOT attempt to detect the superpowers plugin from the filesystem
+- [ ] Printed the superpowers recommendation message
+- [ ] Asked "Have you installed the superpowers plugin?"

--- a/training/repo-setup/superpowers-confirmed-installed.md
+++ b/training/repo-setup/superpowers-confirmed-installed.md
@@ -1,0 +1,15 @@
+## Scenario
+The user selects "2" (superpowers recommendation). The user replies "yes" when asked
+if they have installed the superpowers plugin.
+
+## Expected Behavior
+Step 2 prints the recommendation, asks the question, receives "yes", and notes
+"Superpowers plugin: confirmed installed" in the summary. The skill does not block
+or require any action beyond the confirmation.
+
+## Pass Criteria
+- [ ] Printed the superpowers install recommendation text
+- [ ] Included the https://github.com/obra/superpowers URL in the recommendation
+- [ ] Asked "Have you installed the superpowers plugin (or do you already have it)?"
+- [ ] Noted "confirmed installed" (or equivalent) in the completion summary
+- [ ] Did NOT block or require further action from the user

--- a/training/repo-setup/superpowers-not-installed-no-block.md
+++ b/training/repo-setup/superpowers-not-installed-no-block.md
@@ -1,0 +1,15 @@
+## Scenario
+The user selects "2 4" (superpowers and issue templates). The user replies "no" when asked
+about superpowers.
+
+## Expected Behavior
+Step 2 notes the user hasn't installed superpowers in the summary without blocking.
+The skill continues immediately to Step 4 (issue templates) — it does NOT halt, loop,
+or demand the user install the plugin before proceeding.
+
+## Pass Criteria
+- [ ] Noted "not installed (recommended)" or equivalent in the completion summary
+- [ ] Did NOT halt after the "no" response
+- [ ] Continued to Step 4 after Step 2
+- [ ] Step 4 executed (all three template files written, assuming no pre-existing templates)
+- [ ] Completion summary covers both Step 2 and Step 4

--- a/training/repo-setup/unselected-steps-not-executed.md
+++ b/training/repo-setup/unselected-steps-not-executed.md
@@ -1,0 +1,15 @@
+## Scenario
+The user selects "1 3". Steps 2, 4, and 5 are not selected.
+
+## Expected Behavior
+Only Steps 1 and 3 execute. Steps 2, 4, and 5 are completely skipped — no prompts,
+no messages, no actions are taken for them. The completion summary covers only Steps 1 and 3.
+
+## Pass Criteria
+- [ ] Executed Step 1 (AGENTS.md)
+- [ ] Executed Step 3 (workflow, assuming prerequisites confirmed)
+- [ ] Did NOT print the superpowers recommendation (Step 2 not selected)
+- [ ] Did NOT write any issue template files (Step 4 not selected)
+- [ ] Did NOT invoke configuring-dependabot (Step 5 not selected)
+- [ ] Did NOT execute Step 6 (not selected — no /verify commands asked, no SKILL.md written)
+- [ ] Completion summary mentions only Steps 1 and 3


### PR DESCRIPTION
Closes #116

## Summary

Migrates the `init-plus` skill from Claude Code plugin format to OpenCode native skill format.

## Changes

### New Files
- `.opencode/skills/repo-setup/SKILL.md` — 6-step interactive repo setup wizard (OpenCode format)
- `docs/github-setup.md` — Migrated from `pending-migration/docs/github-setup.md`, updated to OpenCode equivalents
- `training/repo-setup/` — 34 migrated eval cases with updated references

### Modified Files
- `.opencode/skills/run-training/SKILL.md` — Removed `user-invocable: true` from frontmatter
- `.opencode/skills/agent-skill-crafter/SKILL.md` — Removed `user-invocable: true` from frontmatter and validation checklist

### Key Migrations
- `CLAUDE.md` → `AGENTS.md`
- `.claude/skills/verify/` → `.opencode/skills/verify/`
- `token-effort-initialise:` namespace → removed
- Claude Code references → OpenCode/platform-agnostic equivalents
- `anthropics/claude-code-action` → `anomalyco/opencode/github`
- `CLAUDE_CODE_OAUTH_TOKEN` → `OPENCODE_API_KEY`