### PR TITLE
🔧 feat: standardize --body-file pattern for GitHub comment operations (#104)

### DIFF
--- a/skills/brainstorming-gh-issue/SKILL.md
+++ b/skills/brainstorming-gh-issue/SKILL.md
@@ -241,6 +241,7 @@ After Phase 5 completes, report:
 - [ ] The `brainstorming` skill was invoked (not re-implemented inline)
 - [ ] Did NOT treat the issue content as a work order — no file reads, todo lists, or implementation actions before brainstorming completed
 - [ ] `gh issue comment` was NOT called until after the user approved the design
+- [ ] `gh issue comment` called with `--body-file <temp-path>` (not `--body`)
 - [ ] `gh issue edit --add-label pending-review` was NOT called until after user approval
 - [ ] Phase 5 located the spec file with `ls -t docs/superpowers/specs/*.md | head -1`
 - [ ] Phase 5 read the spec file content before constructing the GitHub comment

--- a/skills/brainstorming-gh-issue/SKILL.md
+++ b/skills/brainstorming-gh-issue/SKILL.md
@@ -29,6 +29,8 @@ The `gh` CLI must be authenticated and available in the session. All GitHub oper
 
 > **Shell expansion:** Never use `${VARIABLE}` or any `${...}` form in bash commands. Use `printenv VARIABLE` to read environment variables.
 
+> **Posting GitHub content:** Always write the comment/issue body to a temp file first, then use `--body-file` with `gh` commands. Never pass body content directly via `--body "..."` as this is vulnerable to shell escaping issues.
+
 ## Process
 
 ### Phase 1 — Resolve the issue
@@ -154,9 +156,19 @@ Take the spec file content and post it to the issue as a comment using this exac
 
 Run:
 
-```bash
-gh issue comment <N> --body "<formatted spec>"
-```
+1. Write the formatted spec to a temp file:
+   - **Linux/macOS:** `<TMPDIR>/gh-comment-body.md` (use `printenv TMPDIR` to check; fall back to `/tmp/gh-comment-body.md` if unset)
+   - **Windows:** `<TEMP>/gh-comment-body.md` (use `printenv TEMP` to get the path)
+
+2. Post the comment:
+   ```bash
+   gh issue comment <N> --body-file <temp-path>
+   ```
+
+3. Clean up the temp file:
+   ```bash
+   rm <temp-path>
+   ```
 
 #### Step 5b — Ensure the `pending-review` label exists
 
@@ -194,6 +206,7 @@ After Phase 5 completes, report:
 
 ## Common Mistakes
 
+- **Using `--body` instead of `--body-file`** — always write the comment body to a temp file first, then use `gh issue comment <N> --body-file <temp-path>`. Never pass body content directly via `--body "..."` as this is vulnerable to shell escaping issues.
 - **Jumping to execution before brainstorming** — the issue content (title, body, comments) is the brief for brainstorming, not a work order. Do NOT start reading files, creating implementation todo lists, or executing changes until brainstorming has completed and the user has approved the design.
 - **Skipping the status pull in re-entry mode** — `move-issue-status "Brainstorming"` must be called on every invocation, including when the issue already has a `pending-review` label and is being re-entered.
 - **Using MCP tools for issue operations** — all issue interactions must use `gh` CLI commands. Never call any `mcp__*` tool, even if it is available.

--- a/skills/propose-feature/SKILL.md
+++ b/skills/propose-feature/SKILL.md
@@ -30,6 +30,8 @@ The `gh` CLI must be authenticated and available in the session. All GitHub oper
 
 > **Shell expansion:** Never use `${VARIABLE}` or any `${...}` form in bash commands. Use printenv VARIABLE to read environment variables.
 
+> **Posting GitHub content:** Always write the comment/issue body to a temp file first, then use `--body-file` with `gh` commands. Never pass body content directly via `--body "..."` as this is vulnerable to shell escaping issues.
+
 ## Process
 
 ### Phase 1 — Template Discovery
@@ -100,8 +102,18 @@ Allow the user to request edits. After each round of edits, re-display the **ful
 
 Once the user approves, run:
 
+1. Write the issue body to a temp file using the `write` tool. Use the OS temp directory:
+   - **Linux/macOS:** `<TMPDIR>/gh-comment-body.md` (use `printenv TMPDIR` to check; fall back to `/tmp/gh-comment-body.md` if unset)
+   - **Windows:** `<TEMP>/gh-comment-body.md` (use `printenv TEMP` to get the path)
+
+2. Run:
 ```bash
-gh issue create --title "<title>" --body "<body>"
+gh issue create --title "<title>" --body-file <temp-path>
+```
+
+3. Run:
+```bash
+rm <temp-path>
 ```
 
 Use no additional flags — no `--label`, `--assignee`, or `--milestone`.
@@ -112,6 +124,7 @@ Use no additional flags — no `--label`, `--assignee`, or `--milestone`.
 
 ## Common Mistakes
 
+- **Using `--body` instead of `--body-file`** — always write the issue body to a temp file first, then use `gh issue create --title "<title>" --body-file <temp-path>`. Never pass body content directly via `--body "..."` as this is vulnerable to shell escaping issues.
 - **Using MCP tools** — all issue interactions must use `gh` CLI commands only.
 - **Filing before user approval** — `gh issue create` must NOT be called until the user explicitly approves the draft in Phase 3.
 - **Dumping all interview questions at once** — the interview must be conversational; let answers drive follow-up questions.
@@ -133,6 +146,6 @@ Use no additional flags — no `--label`, `--assignee`, or `--milestone`.
 - [ ] Showed a formatted draft preview (title + body) before filing
 - [ ] Allowed the user to request edits and iterated until explicit approval
 - [ ] Did NOT call `gh issue create` until user explicitly approved
-- [ ] Called `gh issue create --title "..." --body "..."` with no extra flags
+- [ ] Called `gh issue create --title "..." --body-file <temp-path>` with no extra flags
 - [ ] Reported the filed issue URL to the user
 - [ ] No `mcp__` tool was called at any point

--- a/skills/report-bug/SKILL.md
+++ b/skills/report-bug/SKILL.md
@@ -30,6 +30,8 @@ The `gh` CLI must be authenticated and available in the session. All GitHub oper
 
 > **Shell expansion:** Never use `${VARIABLE}` or any `${...}` form in bash commands. Use `printenv VARIABLE` to read environment variables.
 
+> **Posting GitHub content:** Always write the comment/issue body to a temp file first, then use `--body-file` with `gh` commands. Never pass body content directly via `--body "..."` as this is vulnerable to shell escaping issues.
+
 ## Process
 
 ### Phase 1 — Template Discovery (multi-tier)
@@ -115,10 +117,20 @@ Allow the user to request edits. After each round of edits, re-display the **ful
 
 ### Phase 4 — File the Issue
 
-Once the user explicitly approves, run:
+Once the user explicitly approves:
 
+1. Write the issue body to a temp file:
+   - **Linux/macOS:** `<TMPDIR>/gh-comment-body.md` (use `printenv TMPDIR` to check; fall back to `/tmp/gh-comment-body.md` if unset)
+   - **Windows:** `<TEMP>/gh-comment-body.md` (use `printenv TEMP` to get the path)
+
+2. Run:
 ```bash
-gh issue create --title "<title>" --body "<body>"
+gh issue create --title "<title>" --body-file <temp-path>
+```
+
+3. Run:
+```bash
+rm <temp-path>
 ```
 
 Use no additional flags — no `--label`, `--assignee`, or `--milestone`.
@@ -129,6 +141,7 @@ Use no additional flags — no `--label`, `--assignee`, or `--milestone`.
 
 ## Common Mistakes
 
+- **Using `--body` instead of `--body-file`** — always write the issue body to a temp file first, then use `gh issue create --title "<title>" --body-file <temp-path>`. Never pass body content directly via `--body "..."` as this is vulnerable to shell escaping issues.
 - **Using MCP tools** — all issue interactions must use `gh` CLI commands only. Never call any `mcp__*` tool.
 - **Filing before user approval** — `gh issue create` must NOT be called until the user explicitly approves the draft in Phase 3.
 - **Dumping all interview questions at once** — the interview must be conversational; let answers drive follow-up questions.
@@ -155,6 +168,6 @@ Use no additional flags — no `--label`, `--assignee`, or `--milestone`.
 - [ ] Screenshots placeholder (`<!-- Add screenshots here via the GitHub web UI -->`) always present in draft
 - [ ] Allowed the user to request edits and re-displayed the full draft until explicit approval
 - [ ] Did NOT call `gh issue create` until user explicitly approved
-- [ ] Called `gh issue create --title "..." --body "..."` with no extra flags
+- [ ] Called `gh issue create --title "..." --body-file <temp-path>` with no extra flags
 - [ ] Reported the filed issue URL to the user
 - [ ] No `mcp__` tool was called at any point

--- a/skills/triaging-gh-issue/SKILL.md
+++ b/skills/triaging-gh-issue/SKILL.md
@@ -24,6 +24,8 @@ Fetches a single GitHub issue, classifies it by reading its content and searchin
 
 The `gh` CLI must be authenticated and available in the session. All GitHub issue operations use `gh` commands via `Bash`.
 
+> **Posting GitHub content:** Always write the comment/issue body to a temp file first, then use `--body-file` with `gh` commands. Never pass body content directly via `--body "..."` as this is vulnerable to shell escaping issues.
+
 ## Labels
 
 | Label | When to assign |
@@ -173,21 +175,31 @@ Note the current labels from Phase 2:
 
 **Post comment** (always, for every issue — regardless of label action):
 
-Use a heredoc to pass the body to avoid quoting issues:
+1. Write the triage summary to a temp file:
+   - **Linux/macOS:** `<TMPDIR>/gh-comment-body.md` (use `printenv TMPDIR`; fall back to `/tmp/gh-comment-body.md` if unset)
+   - **Windows:** `<TEMP>/gh-comment-body.md` (use `printenv TEMP`)
 
-```bash
-gh issue comment <N> --body "$(cat <<'EOF'
+   The file content (including the `<!-- triaging-gh-issue:summary -->` marker):
+```
 <!-- triaging-gh-issue:summary -->
 ## 🤖 Triage Summary
 
-**Label applied:** \`<label>\`
+**Label applied:** `<label>`
 **Confidence:** <N>%
 
 **Reasoning:** <one-sentence rationale>
 
 **Duplicate check:** <No substantially similar issues found. | Potential duplicate of #<M>: <title>.>
-EOF
-)"
+```
+
+2. Post the comment:
+```bash
+gh issue comment <N> --body-file <temp-path>
+```
+
+3. Clean up:
+```bash
+rm <temp-path>
 ```
 
 If confidence < 70%, the Label applied line reads:
@@ -218,6 +230,7 @@ Triage complete:
 
 ## Common Mistakes
 
+- **Using `--body` instead of `--body-file`** — always write the comment body to a temp file first, then use `gh issue comment <N> --body-file <temp-path>`. Never pass body content directly via `--body "..."` as this is vulnerable to shell escaping issues.
 - **Calling `gh issue list` instead of `gh issue view`** — always use `gh issue view <N>` for single-issue triage.
 - **Calling `git branch --show-current` when args were provided** — only fall back to branch name when no args given.
 - **Not posting the comment** — Phase 5 always posts a triage comment, even for first-time label applications.

--- a/training/skills/brainstorming-gh-issue/uses-body-file-not-body.md
+++ b/training/skills/brainstorming-gh-issue/uses-body-file-not-body.md
@@ -1,0 +1,15 @@
+## Scenario
+
+The user runs `/brainstorming-gh-issue 28`. Brainstorming completes and the spec is posted as a GitHub comment in Phase 5.
+
+## Expected Behaviour
+
+- The skill posts the spec as a GitHub comment using `gh issue comment` with `--body-file` pointing to a temp file, not `--body` with inline content.
+- The spec content is written to a temporary file before posting.
+- The temp file is cleaned up after the comment is posted.
+
+## Pass Criteria
+
+- [ ] `gh issue comment` is called with `--body-file` (not `--body`).
+- [ ] Spec content is written to a temp file before posting.
+- [ ] The temp file is cleaned up after posting.

--- a/training/skills/brainstorming-gh-issue/uses-body-file-not-body.md
+++ b/training/skills/brainstorming-gh-issue/uses-body-file-not-body.md
@@ -1,6 +1,6 @@
 ## Scenario
 
-The user runs `/brainstorming-gh-issue 28`. Brainstorming completes and the spec is posted as a GitHub comment in Phase 5.
+The user runs `/brainstorming-gh-issue 28`. Brainstorming completes and the user approves the design. In Phase 5a (spec posting), the skill posts the finalized spec as a GitHub comment.
 
 ## Expected Behaviour
 
@@ -13,3 +13,9 @@ The user runs `/brainstorming-gh-issue 28`. Brainstorming completes and the spec
 - [ ] `gh issue comment` is called with `--body-file` (not `--body`).
 - [ ] Spec content is written to a temp file before posting.
 - [ ] The temp file is cleaned up after posting.
+
+## Common Mistakes
+
+- Using `--body` with inline spec content instead of `--body-file` — this fails for large specs due to shell argument length limits and makes the command harder to read.
+- Forgetting to write the spec to a temp file before calling `gh issue comment`.
+- Not cleaning up the temp file after posting, leaving orphaned files in the working directory.

--- a/training/skills/propose-feature/uses-body-file-not-body.md
+++ b/training/skills/propose-feature/uses-body-file-not-body.md
@@ -1,0 +1,15 @@
+## Scenario
+The propose-feature skill files a feature issue after user approval.
+
+## Expected Behavior
+The issue body is written to a temp file using the `write` tool, then `gh issue create` is called with `--body-file <temp-path>` (not `--body "..."`). The temp file is cleaned up with `rm` after `gh issue create` succeeds.
+
+## Pass Criteria
+- [ ] `gh issue create` called with `--body-file` flag (not `--body`)
+- [ ] Issue body written to temp file using `write` tool before `gh` command
+- [ ] Temp file cleaned up with `rm` after `gh issue create` succeeds
+
+## Common Mistakes
+- Using `--body` with inline content instead of `--body-file`
+- Not writing the body to a temp file first
+- Not cleaning up the temp file after the issue is created

--- a/training/skills/report-bug/uses-body-file-not-body.md
+++ b/training/skills/report-bug/uses-body-file-not-body.md
@@ -1,0 +1,21 @@
+## Scenario
+
+The report-bug skill files a bug issue after user approval. The issue body is written to a temporary file and submitted via `--body-file`.
+
+## Expected Behaviour
+
+- The issue body is written to a temp file using the `write` tool before calling `gh issue create`.
+- `gh issue create` is called with `--body-file <temp-path>` (not `--body "..."`).
+- The temp file is cleaned up with `rm` after `gh issue create` succeeds.
+
+## Pass Criteria
+
+- [ ] `gh issue create` called with `--body-file` flag (not `--body`).
+- [ ] Issue body written to temp file using `write` tool before `gh` command.
+- [ ] Temp file cleaned up with `rm` after `gh issue create` succeeds.
+
+## Common Mistakes
+
+- Using `--body` with inline content (vulnerable to shell escaping).
+- Not writing to temp file first.
+- Not cleaning up temp file after submission.

--- a/training/skills/triaging-gh-issue/no-heredoc-in-phase5.md
+++ b/training/skills/triaging-gh-issue/no-heredoc-in-phase5.md
@@ -1,0 +1,19 @@
+## Scenario
+
+The triaging-gh-issue skill does not use heredoc patterns in Phase 5.
+
+## Expected Behaviour
+
+Phase 5 uses the three-step `--body-file` pattern (write temp file → gh command → rm) instead of heredoc (`$(cat <<'EOF'...)`).
+
+## Pass Criteria
+
+- [ ] No `$(cat <<'EOF'` or similar heredoc pattern in Phase 5
+- [ ] Phase 5 uses `--body-file` flag with temp file path
+- [ ] Phase 5 includes temp file write step
+
+## Common Mistakes
+
+- Retaining old heredoc pattern from previous skill version
+- Mixing heredoc with `--body-file` (both patterns present)
+- Using `--body` with heredoc instead of `--body-file`

--- a/training/skills/triaging-gh-issue/temp-file-cleaned-up.md
+++ b/training/skills/triaging-gh-issue/temp-file-cleaned-up.md
@@ -1,0 +1,18 @@
+## Scenario
+
+The triaging-gh-issue skill cleaned up the temp file after posting the triage summary.
+
+## Expected Behaviour
+
+After `gh issue comment` succeeds, the skill runs `rm <temp-path>` to remove the temp file.
+
+## Pass Criteria
+
+- [ ] `rm` command executed after `gh issue comment` succeeds
+- [ ] Temp file path matches the one used for writing
+
+## Common Mistakes
+
+- Forgetting to clean up the temp file
+- Cleaning up the wrong file
+- Running `rm` before `gh issue comment` completes

--- a/training/skills/triaging-gh-issue/temp-file-written-before-post.md
+++ b/training/skills/triaging-gh-issue/temp-file-written-before-post.md
@@ -1,0 +1,19 @@
+## Scenario
+
+The triaging-gh-issue skill must write the triage summary to a temp file before posting to GitHub.
+
+## Expected Behaviour
+
+The `write` tool is used to create the temp file containing the triage summary (including the `<!-- triaging-gh-issue:summary -->` marker) before any `gh issue comment` command is executed.
+
+## Pass Criteria
+
+- [ ] `write` tool called before `gh issue comment`
+- [ ] Temp file content includes `<!-- triaging-gh-issue:summary -->` marker as first line
+- [ ] Temp file content includes `## 🤖 Triage Summary` heading
+
+## Common Mistakes
+
+- Calling `gh issue comment` before writing the temp file
+- Omitting the `<!-- triaging-gh-issue:summary -->` HTML comment marker
+- Not including the triage summary heading

--- a/training/skills/triaging-gh-issue/uses-body-file-not-body.md
+++ b/training/skills/triaging-gh-issue/uses-body-file-not-body.md
@@ -1,0 +1,20 @@
+## Scenario
+
+The triaging-gh-issue skill posts a triage summary comment to a GitHub issue after classification.
+
+## Expected Behaviour
+
+The skill writes the triage summary to a temp file first, then uses `gh issue comment <N> --body-file <temp-path>` to post it. The temp file is cleaned up after posting.
+
+## Pass Criteria
+
+- [ ] `gh issue comment` called with `--body-file` flag (not `--body`)
+- [ ] Triage summary written to temp file using `write` tool before `gh` command
+- [ ] Temp file cleaned up with `rm` after `gh issue comment` succeeds
+
+## Common Mistakes
+
+- Using `--body` with inline content (vulnerable to shell escaping issues)
+- Using heredoc (`$(cat <<'EOF'...)`) instead of temp file + `--body-file`
+- Not writing to temp file first
+- Not cleaning up temp file after posting


### PR DESCRIPTION
## Summary

- Replaced `gh issue comment/create --body "..."` with three-step `--body-file` pattern across four skills: `brainstorming-gh-issue`, `triaging-gh-issue`, `report-bug`, and `propose-feature`
- Added prerequisites note and Common Mistakes entry to each SKILL.md about using `--body-file` instead of `--body`
- Created/updated training eval files to verify the `--body-file` pattern, including initial training files for `triaging-gh-issue` which had none

## Changes

| File | Change |
|------|--------|
| `skills/brainstorming-gh-issue/SKILL.md` | Phase 5a: three-step `--body-file` pattern |
| `skills/triaging-gh-issue/SKILL.md` | Phase 5: replaced heredoc with `--body-file` pattern |
| `skills/report-bug/SKILL.md` | Phase 4: three-step `--body-file` pattern |
| `skills/propose-feature/SKILL.md` | Phase 4: three-step `--body-file` pattern |
| `training/skills/brainstorming-gh-issue/uses-body-file-not-body.md` | New eval file |
| `training/skills/report-bug/uses-body-file-not-body.md` | New eval file |
| `training/skills/propose-feature/uses-body-file-not-body.md` | New eval file |
| `training/skills/triaging-gh-issue/*.md` | 4 new eval files (first training files for this skill) |

## Test Plan

- [x] Verify each SKILL.md contains `--body-file` pattern in the correct phase
- [x] Verify each SKILL.md has the prerequisites note about posting GitHub content
- [x] Verify each SKILL.md has the Common Mistakes entry about `--body-file`
- [x] Verify all training eval files exist and cover the `--body-file` criteria
- [x] Verify `triaging-gh-issue` has initial training files covering core behaviors

Closes #104