### PR TITLE
fix: use two-checkout pattern for skill distribution in GHA workflows (#169)

### DIFF
--- a/.github/workflows/triaging-gh-issue.yml
+++ b/.github/workflows/triaging-gh-issue.yml
@@ -30,7 +30,7 @@ jobs:
         run: bash ./install.sh --skill triaging-gh-issue
 
       - name: ✨ Run OpenCode
-        uses: anomalyco/opencode/github@385cb694419f98103af0e8fc6187ddcbcbb6eecb # v1.15.13
+        uses: anomalyco/opencode/github@76c631d198f9ff620e15468e45f3457d50481b57 # v1.16.2
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/triaging-gh-issue.yml
+++ b/.github/workflows/triaging-gh-issue.yml
@@ -19,18 +19,23 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: ⤵️ Checkout skill source
+        uses: actions/checkout@v6
+        with:
+          repository: HeadlessTarry/Token-Effort
+          path: _skill-source
+          persist-credentials: false
+
+      - name: ⚙️ Install skill
+        run: bash _skill-source/install.sh --skill triaging-gh-issue
+
       - name: ⤵️ Checkout repository
         uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - name: ⚙️ Install skill
-        # Do not install locally, as opencode will see a dirty local branch and raise a PR for the changes
-        # See https://github.com/anomalyco/opencode/issues/21636
-        run: bash ./install.sh --skill triaging-gh-issue
-
       - name: ✨ Run OpenCode
-        uses: anomalyco/opencode/github@76c631d198f9ff620e15468e45f3457d50481b57 # v1.16.2
+        uses: anomalyco/opencode/github@385cb694419f98103af0e8fc6187ddcbcbb6eecb # v1.15.13
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/skills/repo-setup/SKILL.md
+++ b/skills/repo-setup/SKILL.md
@@ -384,6 +384,7 @@ No git commit is made. The user decides what to commit.
 - [ ] Step 3: Referenced docs/github-setup.md for prerequisites
 - [ ] Step 3: Asked if prerequisites set up; skipped workflow on "no"/"skip"
 - [ ] Step 3: Warned and confirmed before overwriting existing workflow file
+- [ ] Step 3 resolves the OpenCode action SHA via `gh api` before writing the workflow file
 - [ ] Step 4: Warned and confirmed before overwriting any existing template files
 - [ ] Step 4: Wrote all three template files with correct content
 - [ ] Step 5: Delegated to `configuring-dependabot` via Skill tool

--- a/skills/repo-setup/SKILL.md
+++ b/skills/repo-setup/SKILL.md
@@ -165,12 +165,22 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - name: Checkout repository
+      - name: ⤵️ Checkout skill source
+        uses: actions/checkout@v6
+        with:
+          repository: HeadlessTarry/Token-Effort
+          path: _skill-source
+          persist-credentials: false
+
+      - name: ⚙️ Install skill
+        run: bash _skill-source/install.sh --skill triaging-gh-issue
+
+      - name: ⤵️ Checkout repository
         uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - name: Run skill
+      - name: ✨ Run OpenCode
         uses: anomalyco/opencode/github@<resolved-reference>
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}

--- a/skills/repo-setup/SKILL.md
+++ b/skills/repo-setup/SKILL.md
@@ -366,6 +366,7 @@ No git commit is made. The user decides what to commit.
 - **Not confirming commands before writing** — always echo the command list back to the user and wait for a yes confirmation before writing `.opencode/skills/verify/SKILL.md`.
 - **Writing the file when the user skips** — if the user says they don't know or wants to skip, do not generate any file. Log the "not configured" message and move on.
 - **Making a git commit after setup** — no git commit is made. The user decides what to commit.
+- **Hardcoding `@main` in Step 3** — the skill must resolve the OpenCode action version dynamically via `gh api` before writing the workflow file. Never hardcode `@main` or any unpinned branch reference.
 
 ## Eval
 

--- a/skills/repo-setup/SKILL.md
+++ b/skills/repo-setup/SKILL.md
@@ -384,7 +384,7 @@ No git commit is made. The user decides what to commit.
 - [ ] Step 3: Referenced docs/github-setup.md for prerequisites
 - [ ] Step 3: Asked if prerequisites set up; skipped workflow on "no"/"skip"
 - [ ] Step 3: Warned and confirmed before overwriting existing workflow file
-- [ ] Step 3 resolves the OpenCode action SHA via `gh api` before writing the workflow file
+- [ ] Step 3: Resolves the OpenCode action SHA via `gh api` before writing the workflow file
 - [ ] Step 4: Warned and confirmed before overwriting any existing template files
 - [ ] Step 4: Wrote all three template files with correct content
 - [ ] Step 5: Delegated to `configuring-dependabot` via Skill tool

--- a/skills/repo-setup/SKILL.md
+++ b/skills/repo-setup/SKILL.md
@@ -124,6 +124,21 @@ If `.github/workflows/triaging-gh-issue.yml` exists:
 
 Wait for confirmation. If the user says no, note "Triage workflow: skipped (overwrite declined)" in the summary and continue.
 
+**Resolve OpenCode action version**: Before writing the workflow file, resolve the latest release commit SHA:
+
+1. Run `gh api repos/anomalyco/opencode/releases/latest --jq .tag_name` to get the latest release tag (e.g. `v1.15.13`).
+2. Run `gh api repos/anomalyco/opencode/commits/tags/<tag> --jq .sha` to resolve that tag to a full commit SHA.
+
+On success, construct the pinned reference as `<sha> # <tag>` (e.g. `385cb694419f98103af0e8fc6187ddcbcbb6eecb # v1.15.13`).
+
+On failure of either command, use the fallback value:
+
+```
+385cb694419f98103af0e8fc6187ddcbcbb6eecb # v1.15.13
+```
+
+Substitute the resolved (or fallback) reference into the `uses:` line of the workflow template below.
+
 Create directory `.github/workflows/` if it does not exist.
 
 Write `.github/workflows/triaging-gh-issue.yml` with the following OpenCode-format workflow content:
@@ -156,7 +171,7 @@ jobs:
           persist-credentials: false
 
       - name: Run skill
-        uses: anomalyco/opencode/github@main
+        uses: anomalyco/opencode/github@<resolved-reference>
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/skills/repo-setup/SKILL.md
+++ b/skills/repo-setup/SKILL.md
@@ -158,7 +158,7 @@ on:
 
 jobs:
   triage:
-    name: Triage
+    name: 🔍 Triage
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Closes #169

## Summary
- Updated `skills/repo-setup/SKILL.md` Step 3 workflow template to use two-checkout pattern (checkout Token-Effort → install skill → checkout target repo)
- Updated `.github/workflows/triaging-gh-issue.yml` to use the same two-checkout pattern
- Added emoji prefix to triage job name (`🔍 Triage`) to match CI/CD convention
- SHA-pinned OpenCode action reference preserved from base branch

## Test Plan
- [x] Verify generated workflow from repo-setup Step 3 uses two-checkout pattern — `skills/repo-setup/SKILL.md` contains `Checkout skill source` → `Install skill` → `Checkout repository` steps with `_skill-source` path
- [x] Verify Token-Effort's own triage workflow uses two-checkout pattern — `.github/workflows/triaging-gh-issue.yml` has all three steps with `_skill-source` path
- [x] Verify SHA-pinned OpenCode action reference is preserved — `@385cb694419f98103af0e8fc6187ddcbcbb6eecb # v1.15.13`
- [x] Verify YAML syntax valid — `python yaml.safe_load` passes
- [x] Verify SHA resolution instructions present — `gh api` dynamic resolution + fallback documented