### PR TITLE
fix: remove hardcoded model version pins for resilience

### DIFF
--- a/.github/workflows/triaging-gh-issue.yml
+++ b/.github/workflows/triaging-gh-issue.yml
@@ -40,6 +40,6 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          model: opencode-go/qwen3.6-plus
+          model: ${{ vars.OPENCODE_MODEL || 'opencode-go/qwen3.7-plus' }}
           prompt: |
             Use the triaging-gh-issue skill to triage issue ${{ github.event.issue.number || inputs.issue_number }}.

--- a/agents/reviewer-dead-code.md
+++ b/agents/reviewer-dead-code.md
@@ -2,7 +2,6 @@
 name: reviewer-dead-code
 description: Use when reviewing files for dead code — unreachable branches, unused symbols, orphaned files, stale flags, and commented-out blocks.
 mode: subagent
-model: opencode-go/qwen3.5-plus
 permission:
   edit: deny
   bash:

--- a/agents/reviewer-docs.md
+++ b/agents/reviewer-docs.md
@@ -2,7 +2,6 @@
 name: reviewer-docs
 description: Use when reviewing documentation files (README.md, docs/*, docs/**) for quality, accuracy, and completeness — read-only, outputs structured VERDICT.
 mode: subagent
-model: opencode-go/qwen3.5-plus
 permission:
   edit: deny
   bash:

--- a/agents/reviewer-newcomer.md
+++ b/agents/reviewer-newcomer.md
@@ -2,7 +2,6 @@
 name: reviewer-newcomer
 description: Use when reviewing source files for naming clarity, missing comments, implicit assumptions, and error message quality.
 mode: subagent
-model: opencode-go/qwen3.5-plus
 permission:
   edit: deny
   bash:

--- a/docs/decisions/2026-07-model-version-resilience.md
+++ b/docs/decisions/2026-07-model-version-resilience.md
@@ -1,0 +1,25 @@
+# 2026-07-model-version-resilience
+
+> **Status:** Active
+> **Issue:** [#178 — Hardcoded OpenCode model versions cause 'Model not found' errors when versions are retired](https://github.com/HeadlessTarry/Token-Effort/issues/178)
+> **Date:** 2026-07-04
+
+## Context
+
+Multiple agents, skills, and workflows in this repo pinned specific OpenCode model versions (e.g. `opencode-go/qwen3.5-plus`, `opencode-go/qwen3.6-plus`). When those versions were retired or unavailable to a user's account, invoking the affected agent/skill/workflow failed with "Model not found" errors. OpenCode has no built-in model aliasing — model IDs are always version-specific.
+
+## Decision
+
+Two-part approach:
+
+1. **Subagent agent files:** Remove the `model:` field from YAML frontmatter in `agents/reviewer-newcomer.md`, `agents/reviewer-docs.md`, and `agents/reviewer-dead-code.md`. Subagents without a `model:` field inherit the model of the parent agent that invokes them. Zero maintenance.
+
+2. **GitHub Actions workflow & skill templates:** Replace hardcoded model IDs with `${{ vars.OPENCODE_MODEL || 'opencode-go/qwen3.7-plus' }}` expression in `.github/workflows/triaging-gh-issue.yml`, `skills/repo-setup/SKILL.md`, and `training/skills/repo-setup/step3-workflow-content-accuracy.md`. Uses a GitHub repo/org variable with a sensible fallback default.
+
+## Consequences
+
+- Subagents may run on a more expensive model than strictly needed for review tasks. This cost trade-off is accepted in exchange for zero maintenance.
+- Works out-of-the-box with the fallback default (`qwen3.7-plus`) — no setup required.
+- When a model is retired, updating the `OPENCODE_MODEL` repo/org variable in GitHub settings propagates to all workflows immediately — no code changes needed.
+- The user must create the `OPENCODE_MODEL` variable manually at org/repo level.
+- The repo-setup skill generates workflows with the same expression, so downstream repos get the same resilience.

--- a/skills/repo-setup/SKILL.md
+++ b/skills/repo-setup/SKILL.md
@@ -186,7 +186,7 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          model: opencode-go/qwen3.6-plus
+          model: ${{ vars.OPENCODE_MODEL || 'opencode-go/qwen3.7-plus' }}
           prompt: |
             Use the triaging-gh-issue skill to triage issue ${{ github.event.issue.number || inputs.issue_number }}.
 ```

--- a/training/skills/repo-setup/step3-workflow-content-accuracy.md
+++ b/training/skills/repo-setup/step3-workflow-content-accuracy.md
@@ -14,6 +14,6 @@ input), and prompt text.
 - [ ] Uses `anomalyco/opencode/github` action
 - [ ] Uses `secrets.GITHUB_TOKEN` for authentication
 - [ ] Uses `secrets.OPENCODE_API_KEY` env var
-- [ ] Model is `opencode-go/qwen3.6-plus`
+- [ ] Model uses `vars.OPENCODE_MODEL` with fallback default
 - [ ] Prompt instructs to use the triaging-gh-issue skill
 - [ ] Prompt passes the issue number: `${{ github.event.issue.number || inputs.issue_number }}`


### PR DESCRIPTION
## Summary
- Remove `model:` field from 3 subagent files so they inherit the parent agent's model (zero maintenance)
- Replace hardcoded model IDs in workflow and skill templates with `${{ vars.OPENCODE_MODEL || 'opencode-go/qwen3.7-plus' }}` for configurable fallback

Closes #178