### PR TITLE
fix: prevent duplicate triage comments by disabling OpenCode share

### DIFF
--- a/.github/workflows/triaging-gh-issue.yml
+++ b/.github/workflows/triaging-gh-issue.yml
@@ -48,5 +48,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ vars.OPENCODE_MODEL || 'opencode-go/qwen3.7-plus' }}
+          share: false
           prompt: |
             Use the triaging-gh-issue skill to triage issue ${{ github.event.issue.number || inputs.issue_number }}.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,3 @@ graph LR
 ```
 
 Issue states (📋 New, 🧠 Brainstorming, 🏗️ Building, ✅ Done) correspond to GitHub Project board columns. Each skill automatically advances the issue from an earlier status.
-
-## Migration Status
-
-This repo is migrating from a Claude Code plugin to native OpenCode skills and agents. The `pending-migration/` directory contains legacy content that will be removed once migration is complete. Do not modify or add to it.

--- a/skills/repo-setup/SKILL.md
+++ b/skills/repo-setup/SKILL.md
@@ -187,6 +187,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ vars.OPENCODE_MODEL || 'opencode-go/qwen3.7-plus' }}
+          share: false
           prompt: |
             Use the triaging-gh-issue skill to triage issue ${{ github.event.issue.number || inputs.issue_number }}.
 ```

--- a/training/skills/repo-setup/step3-workflow-content-accuracy.md
+++ b/training/skills/repo-setup/step3-workflow-content-accuracy.md
@@ -15,5 +15,6 @@ input), and prompt text.
 - [ ] Uses `secrets.GITHUB_TOKEN` for authentication
 - [ ] Uses `secrets.OPENCODE_API_KEY` env var
 - [ ] Model uses `vars.OPENCODE_MODEL` with fallback default
+- [ ] `share: false` is set to prevent duplicate comments
 - [ ] Prompt instructs to use the triaging-gh-issue skill
 - [ ] Prompt passes the issue number: `${{ github.event.issue.number || inputs.issue_number }}`


### PR DESCRIPTION
Closes #167

## Problem
The triage workflow was posting two comments to new issues:
1. A 'Triage Summary' from the triage skill (with `<!-- triaging-gh-issue:summary -->` marker)
2. An OpenCode session summary comment (from the share feature)

## Root Cause
The OpenCode GitHub Action's `share` parameter defaults to `true` for public repositories, causing it to automatically post a session share comment in addition to the triage skill's comment.

## Solution
Added `share: false` to the OpenCode action configuration in:
- `.github/workflows/triaging-gh-issue.yml` (live workflow)
- `skills/repo-setup/SKILL.md` (template for new repos)

Also updated the training eval for `repo-setup` to prevent regression:
- `training/skills/repo-setup/step3-workflow-content-accuracy.md`

## Changes
- Added `share: false` to workflow configuration
- Updated skill template to include `share: false`
- Added eval criterion to verify `share: false` is set
- Removed obsolete Migration Status section from README.md