### PR TITLE
fix: use correct 'plugin' key in opencode.json

### DIFF
--- a/lib/config.ps1
+++ b/lib/config.ps1
@@ -24,8 +24,8 @@ function Get-ConfigPlugins {
 
     try {
         $config = Get-Content $ConfigPath -Raw | ConvertFrom-Json
-        if ($config.plugins) {
-            return ,@($config.plugins)
+        if ($config.plugin) {
+            return ,@($config.plugin)
         }
         return ,@()
     }
@@ -84,12 +84,12 @@ function Set-ConfigPlugins {
         $config = [PSCustomObject]@{}
     }
 
-    if (-not $config.plugins) {
-        $config | Add-Member -NotePropertyName "plugins" -NotePropertyValue @()
+    if (-not $config.plugin) {
+        $config | Add-Member -NotePropertyName "plugin" -NotePropertyValue @()
     }
 
     foreach ($spec in $newSpecs) {
-        $config.plugins += $spec
+        $config.plugin += $spec
     }
 
     # Write

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -30,7 +30,7 @@ config_read_plugins() {
         echo "Error: Invalid JSON in $config_path — aborting. Fix the JSON or delete the file to let the installer recreate it." >&2
         return 1
     fi
-    jq -c '.plugins // []' "$config_path"
+    jq -c '.plugin // []' "$config_path"
 }
 
 # Check if a plugin spec already exists in the plugins array
@@ -87,19 +87,19 @@ config_apply_plugins() {
     # Build updated JSON
     local updated
     if [[ ! -f "$config_path" ]]; then
-        updated='{"plugins":[]}'
+        updated='{"plugin":[]}'
     else
         updated=$(cat "$config_path")
     fi
 
     # Ensure plugins array exists
-    if ! echo "$updated" | jq -e '.plugins' >/dev/null 2>&1; then
-        updated=$(echo "$updated" | jq '. + {"plugins":[]}')
+    if ! echo "$updated" | jq -e '.plugin' >/dev/null 2>&1; then
+        updated=$(echo "$updated" | jq '. + {"plugin":[]}')
     fi
 
     # Append each new plugin
     for spec in "${new_specs[@]}"; do
-        updated=$(echo "$updated" | jq --arg s "$spec" '.plugins += [$s]')
+        updated=$(echo "$updated" | jq --arg s "$spec" '.plugin += [$s]')
     done
 
     # Write


### PR DESCRIPTION
## Summary
- Fixed `lib/config.sh` and `lib/config.ps1` to write `"plugin"` (singular) instead of `"plugins"` (plural) — matching the [official OpenCode config schema](https://opencode.ai/docs/plugins)

## Root Cause
The install system was using `"plugins"` as the JSON key, but OpenCode expects `"plugin"`. This caused the plugin entry to be silently ignored.

## Test Plan
- [x] Run `./install.sh --local` and verify `opencode.json` contains `"plugin"` key
- [x] Verify bash syntax valid

Closes #191