### PR TITLE
feat: add disclose-ai-content skill with training evals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,4 +14,4 @@ Single-context layout — one `CONTEXT.md` at root, ADRs in `docs/adr/`. See `do
 
 ### Creating skills
 
-A new skill is one ticket: definition + eval suite + training to 100%. Do not split into horizontal layers. See `docs/agents/creating-skills.md`.
+A new skill is one ticket: SKILL.md + training evals + iterate training to 100%. Do not split into separate tickets for "write the skill", "write the evals", "run training" — the skill is not verifiable without evals, and the work is not complete until evals are green. See `docs/agents/creating-skills.md`.

--- a/skills/disclose-ai-content/SKILL.md
+++ b/skills/disclose-ai-content/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: disclose-ai-content
+description: Always apply when creating or editing GitHub issues, pull requests, or comments. Prepends a visual banner to AI-generated or AI-edited content.
+user-invocable: false
+---
+
+# ✨ Disclose AI-Generated Content
+
+## Overview
+
+Automatically prepends a visual banner to any GitHub content that was AI-generated or AI-edited. This ensures readers know before they start reading whether the content was created by a human or an agent.
+
+**Not user-invocable.** This skill activates automatically whenever an agent creates or edits GitHub issues, pull requests, or comments.
+
+## When to Use
+
+**Apply the banner when:**
+- You write the primary content of an issue body, PR body, or comment
+- You substantially edit human-written content (restructuring, rewriting, adding significant new material)
+- You make minimal edits (typos, formatting, grammar) — even small changes require the banner
+
+**Do not apply the banner when:**
+- The content is entirely human-written and you are only performing mechanical operations (e.g., applying labels, closing issues)
+- You are quoting other content within your post (the banner applies to your commentary, not the quoted material)
+- The user explicitly opts out in the same prompt (see Opt-out section)
+
+## Prerequisites
+
+None. This skill requires no external tools, CLI authentication, or MCP servers. It is purely instructional and applies to agent behavior when posting GitHub content.
+
+## Process
+
+### Step 1 — Check Scope
+
+Before writing any GitHub content, determine if the banner applies:
+
+- **Applies to:** Issue bodies, PR bodies, issue comments, PR review comments
+- **Does not apply to:** Code blocks, commit messages, discussions, wikis, file contents
+
+If the content is out of scope, skip the banner entirely.
+
+### Step 2 — Check for Opt-out
+
+Review the user's prompt for natural-language opt-out requests such as:
+- "skip the banner"
+- "don't add the AI disclaimer"
+- "no AI disclosure needed"
+
+If the user opts out, do not add the banner. Proceed to post the content without disclosure.
+
+### Step 3 — Check for Existing Banner (Deduplication)
+
+If editing existing content, check the **first 5 lines** for the exact banner text:
+```
+> ✨ AI-generated content. Mistakes do happen - please review carefully.
+```
+
+If found, skip adding the banner again. Proceed with the edit.
+
+### Step 4 — Prepend Banner
+
+If the banner applies, is not opted out, and is not already present, prepend it as the **first line** of the content:
+
+```markdown
+> ✨ AI-generated content. Mistakes do happen - please review carefully.
+[Your content starts here]
+```
+
+Ensure the banner is clearly separated from the content that follows (typically with a blank line).
+
+### Step 5 — Post Content
+
+Post the content using the appropriate GitHub CLI command or API. The banner is now part of the content body.
+
+## Banner Format
+
+**Exact text:**
+```
+> ✨ AI-generated content. Mistakes do happen - please review carefully.
+```
+
+**Placement rules:**
+- Must be the **first line** of the content, before any other text
+
+**Example:**
+```markdown
+> ✨ AI-generated content. Mistakes do happen - please review carefully.
+
+## Summary
+
+This PR implements...
+```
+
+## Deduplication
+
+Before adding the banner, check the **first 5 lines** of existing content. If the exact banner text is already present, do not add it again.
+
+**Check for this exact string:**
+```
+> ✨ AI-generated content. Mistakes do happen - please review carefully.
+```
+
+If found, skip adding the banner. If not found, prepend it.
+
+## Scope
+
+**Applies to:**
+- GitHub issue bodies
+- Pull request bodies
+- Issue comments
+- Pull request review comments
+
+**Does not apply to:**
+- Code blocks within content (the banner applies to the surrounding prose, not to code)
+- GitHub Discussions
+- GitHub Wikis
+- Commit messages
+- File contents in the repository
+
+## Opt-out
+
+Users can skip the banner by including natural language in the prompt that generates the content.
+
+**Recognize these variations:**
+- "skip the banner"
+- "don't add the AI disclaimer"
+- "no AI disclosure needed"
+- "omit the AI banner"
+- "post without the disclosure"
+
+When the user opts out, do not prepend the banner. This is a per-prompt decision; the next prompt will require the banner again unless it also opts out.
+
+## Quoted Content
+
+When your post includes quotes of other content (human-written or AI-generated), the banner applies only to **your generated commentary**, not to the quoted material.
+
+**Correct:**
+```markdown
+> ✨ AI-generated content. Mistakes do happen - please review carefully.
+Here's my analysis of the issue:
+
+> @user wrote:
+> The system crashes when...
+
+Based on this, I recommend...
+```
+
+The banner discloses your analysis, not the quoted text from @user.
+
+## Common Mistakes
+
+- **Adding the banner to code blocks** — the banner applies to prose content, not to code examples within the content
+- **Placing the banner after other content** — it must be the very first line
+- **Duplicating the banner** — always check the first 5 lines before adding; if it's already there, skip
+- **Applying to out-of-scope content** — do not add the banner to commit messages, discussions, wikis, or file contents
+- **Forgetting to apply to minimal edits** — even typo fixes and formatting changes require the banner
+- **Skipping the banner when editing human content** — if you substantially edit or rewrite human content, the banner is required
+- **Misinterpreting opt-out** — opt-out must be explicit in the same prompt; default is always-on
+
+## Eval
+
+- [ ] Banner is the first line of all AI-generated issue bodies, PR bodies, and comments
+- [ ] Banner text is exactly: `> ✨ AI-generated content. Mistakes do happen - please review carefully.`
+- [ ] Banner is clearly separated from following content (typically with a blank line)
+- [ ] Banner is not duplicated when editing content that already contains it
+- [ ] Banner is applied even for minimal edits (typos, formatting)
+- [ ] Banner is not applied to code blocks, commit messages, discussions, or wikis
+- [ ] Opt-out is respected when the user explicitly requests it in the prompt
+- [ ] Quoted content is not covered by the banner; only the agent's commentary is disclosed

--- a/training/skills/disclose-ai-content/banner-placement-comment.md
+++ b/training/skills/disclose-ai-content/banner-placement-comment.md
@@ -1,0 +1,11 @@
+## Scenario
+An agent posts a comment on a GitHub issue in response to a user's question. The agent analyzes the problem and provides recommendations.
+
+## Expected Behavior
+The agent writes the comment with the AI content banner as the very first line, followed by the analysis and recommendations. A blank line separates the banner from the content.
+
+## Pass Criteria
+- [ ] Banner is the first line of the comment
+- [ ] Banner text is exactly: `> ✨ AI-generated content. Mistakes do happen - please review carefully.`
+- [ ] Blank line separates banner from the next section
+- [ ] Comment contains the analysis and recommendations

--- a/training/skills/disclose-ai-content/banner-placement-new-issue.md
+++ b/training/skills/disclose-ai-content/banner-placement-new-issue.md
@@ -1,0 +1,11 @@
+## Scenario
+An agent creates a new GitHub issue to report a bug. The user provides a description of the problem, reproduction steps, and expected behavior.
+
+## Expected Behavior
+The agent writes the issue body with the AI content banner as the very first line, followed by the formatted issue content. A blank line separates the banner from the content.
+
+## Pass Criteria
+- [ ] Banner is the first line of the issue body
+- [ ] Banner text is exactly: `> ✨ AI-generated content. Mistakes do happen - please review carefully.`
+- [ ] Blank line separates banner from the next section
+- [ ] Issue body contains all user-provided information (description, reproduction steps, expected behavior)

--- a/training/skills/disclose-ai-content/banner-placement-pr-body.md
+++ b/training/skills/disclose-ai-content/banner-placement-pr-body.md
@@ -1,0 +1,11 @@
+## Scenario
+An agent creates a pull request to implement a new feature. The user provides context about what needs to be built and the agent writes the PR description.
+
+## Expected Behavior
+The agent writes the PR body with the AI content banner as the very first line, followed by the PR description content. A blank line separates the banner from the content.
+
+## Pass Criteria
+- [ ] Banner is the first line of the PR body
+- [ ] Banner text is exactly: `> ✨ AI-generated content. Mistakes do happen - please review carefully.`
+- [ ] Blank line separates banner from the next section
+- [ ] PR body contains the feature implementation details

--- a/training/skills/disclose-ai-content/deduplication-banner-already-present.md
+++ b/training/skills/disclose-ai-content/deduplication-banner-already-present.md
@@ -1,0 +1,12 @@
+## Scenario
+An agent edits an existing GitHub issue that already has the AI content banner at the top. The user asks the agent to add more information to the issue.
+
+## Expected Behavior
+The agent checks the first 5 lines of the existing content, finds the banner is already present, and does not add it again. The agent updates the issue content without duplicating the banner.
+
+## Pass Criteria
+- [ ] Agent checks the first 5 lines of existing content
+- [ ] Agent identifies that the banner is already present
+- [ ] Agent does not add a duplicate banner
+- [ ] Issue content is updated with the new information
+- [ ] Only one instance of the banner exists in the final content

--- a/training/skills/disclose-ai-content/minimal-edit-requires-banner.md
+++ b/training/skills/disclose-ai-content/minimal-edit-requires-banner.md
@@ -1,0 +1,11 @@
+## Scenario
+An agent fixes a typo in an existing GitHub issue body. The original issue was written by a human and does not have the AI content banner.
+
+## Expected Behavior
+Even though this is a minimal edit (just fixing a typo), the agent applies the AI content banner because the content has been AI-edited. The banner is prepended to the issue body.
+
+## Pass Criteria
+- [ ] Banner is the first line of the issue body after the edit
+- [ ] Banner text is exactly: `> ✨ AI-generated content. Mistakes do happen - please review carefully.`
+- [ ] The typo is fixed in the content
+- [ ] The rest of the original content is preserved

--- a/training/skills/disclose-ai-content/opt-out-explicit-request.md
+++ b/training/skills/disclose-ai-content/opt-out-explicit-request.md
@@ -1,0 +1,11 @@
+## Scenario
+An agent creates a GitHub issue, but the user explicitly says "skip the banner" or "don't add the AI disclaimer" in the prompt.
+
+## Expected Behavior
+The agent recognizes the opt-out request and does not prepend the banner to the issue body. The issue is created without the AI content disclosure.
+
+## Pass Criteria
+- [ ] Agent recognizes the opt-out request in the prompt
+- [ ] Banner is NOT present in the issue body
+- [ ] Issue content is still created with all user-provided information
+- [ ] Agent does not mention or apologize for skipping the banner

--- a/training/skills/disclose-ai-content/out-of-scope-commit-message.md
+++ b/training/skills/disclose-ai-content/out-of-scope-commit-message.md
@@ -1,0 +1,10 @@
+## Scenario
+An agent creates a git commit message to commit changes to the repository.
+
+## Expected Behavior
+The agent does NOT apply the AI content banner to the commit message. The banner only applies to GitHub issues, PRs, and comments — not to commit messages.
+
+## Pass Criteria
+- [ ] Banner is NOT present in the commit message
+- [ ] Commit message follows conventional commit format
+- [ ] Commit message contains the summary of changes

--- a/training/skills/disclose-ai-content/quoted-content-handling.md
+++ b/training/skills/disclose-ai-content/quoted-content-handling.md
@@ -1,0 +1,12 @@
+## Scenario
+An agent posts a comment that includes a quote from another user's comment, followed by the agent's analysis and recommendations.
+
+## Expected Behavior
+The agent prepends the banner to the comment (covering the agent's generated commentary), then includes the quoted content from the other user, followed by the agent's analysis. The banner applies to the agent's commentary, not the quoted material.
+
+## Pass Criteria
+- [ ] Banner is the first line of the comment
+- [ ] Banner text is exactly: `> ✨ AI-generated content. Mistakes do happen - please review carefully.`
+- [ ] Quoted content from the other user is included with proper markdown quote syntax
+- [ ] Agent's analysis and recommendations follow the quoted content
+- [ ] The banner covers the agent's commentary, not the quoted material


### PR DESCRIPTION
Closes #166, closes #204

## 🎯 What

Adds the `disclose-ai-content` skill — an always-on instruction that automatically prepends a visual banner to AI-generated or AI-edited GitHub content (issues, PRs, comments).

## 📦 Deliverables

- **`skills/disclose-ai-content/SKILL.md`** — skill definition covering banner format, scope, deduplication, opt-out, quoted content handling
- **`training/skills/disclose-ai-content/*.md`** — 8 eval scenarios (banner placement ×3, deduplication, minimal edits, opt-out, quoted content, out-of-scope)
- **`CLAUDE.md`** — updated "Creating skills" guidance with explicit single-ticket principle

## ✅ Verification

- Training baseline: **100% pass rate** (33/33 criteria across 8 evals)
- Code review completed — addressed section naming consistency, added missing Prerequisites/Process sections, removed scope-creep constraints

## 📝 Banner Format

```
> ✨ AI-generated content. Mistakes do happen - please review carefully.
```

Applied automatically to all AI-generated/edited GitHub content. Opt-out via natural language in the prompt.
