### PR TITLE
docs: add long content guidelines for issue-tracker

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -4,14 +4,32 @@ Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all o
 
 ## Conventions
 
-- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Create an issue**: `gh issue create --title "..." --body-file -` with a heredoc piped to stdin.
 - **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
-- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
-- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments`
+  with `--jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+  and appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body-file -` with a heredoc piped to stdin.
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
 - **Close**: `gh issue close <number> --comment "..."`
 
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Long content guidelines
+
+For any issue/comment body over ~500 characters:
+- **Always** use `--body-file -` with heredoc (never `--body "..."`)
+- This avoids JSON serialization issues when passing markdown through the tool layer
+- Quote the heredoc delimiter (`<< 'EOF'`) to prevent shell variable expansion
+
+Example:
+```bash
+gh issue comment 42 --body-file - << 'EOF'
+## Implementation Spec
+
+Long content with code blocks, lists, etc.
+EOF
+```
 
 ## Pull requests as a triage surface
 
@@ -42,4 +60,4 @@ Used by `/wayfinder`. The **map** is a single issue with **child** issues as tic
 - **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
 - **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
 - **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
-- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.
+- **Resolve**: `gh issue comment <n> --body "<answer>"` (for short content), then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.


### PR DESCRIPTION
## Summary

Updates `docs/agents/issue-tracker.md` with guidelines for handling long content in issue and comment bodies.

## Changes

- **Updated command examples**: Changed `--body "..."` to `--body-file -` with heredoc for `gh issue create` and `gh issue comment` commands
- **Added new section**: "Long content guidelines" with best practices for content over ~500 characters
- **Improved formatting**: Better line breaks and structure for readability
- **Clarified resolve step**: Added note about using `--body-file -` only for short content in the wayfinder resolve example

## Rationale

Using `--body-file -` with heredoc avoids JSON serialization issues when passing markdown through the tool layer, especially for long content with code blocks, lists, or special characters.